### PR TITLE
[FE] 게시글 삭제기능, 댓글 수정 삭제 기능 구현 

### DIFF
--- a/client/src/Components/CommentContent.jsx
+++ b/client/src/Components/CommentContent.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Item, Content, Info } from './CommentContent.style';
+import CommentEditDelete from './CommentEditDelete';
+
+function CommentContent({ item, setIsEdit }) {
+  // 로그인된 사용자의 멤버아이디를 임시로 지정
+  const loginId = 'MEM_1';
+
+  return (
+    <Item.Content>
+      <Content.Info>
+        <Info.Name>{item.userName}</Info.Name>
+        <Info.Content>
+          {/*item.content*/}가장긴댓ㅇ르 사용했을때는 어떻게 보일까요 가장 긴
+          탟ㅅ을 사용했을때는 어떻ㄱ세 표시가 될까요
+        </Info.Content>
+        {loginId === item.memberId ? (
+          <CommentEditDelete
+            commentId={item.commentId}
+            memberId={item.memberId}
+            setIsEdit={setIsEdit}
+          />
+        ) : undefined}
+      </Content.Info>
+      <Content.CreateAt>{item.createAt}</Content.CreateAt>
+    </Item.Content>
+  );
+}
+
+export default CommentContent;

--- a/client/src/Components/CommentContent.jsx
+++ b/client/src/Components/CommentContent.jsx
@@ -10,10 +10,7 @@ function CommentContent({ item, setIsEdit }) {
     <Item.Content>
       <Content.Info>
         <Info.Name>{item.userName}</Info.Name>
-        <Info.Content>
-          {/*item.content*/}가장긴댓ㅇ르 사용했을때는 어떻게 보일까요 가장 긴
-          탟ㅅ을 사용했을때는 어떻ㄱ세 표시가 될까요
-        </Info.Content>
+        <Info.Content>{item.content}</Info.Content>
         {loginId === item.memberId ? (
           <CommentEditDelete
             commentId={item.commentId}

--- a/client/src/Components/CommentContent.jsx
+++ b/client/src/Components/CommentContent.jsx
@@ -3,8 +3,8 @@ import { Item, Content, Info } from './CommentContent.style';
 import CommentEditDelete from './CommentEditDelete';
 
 function CommentContent({ item, setIsEdit }) {
-  // 로그인된 사용자의 멤버아이디를 임시로 지정
-  const loginId = 'MEM_1';
+  // 로그인된 사용자의 멤버아이디
+  const loginId = sessionStorage.getItem('memberId');
 
   return (
     <Item.Content>

--- a/client/src/Components/CommentContent.style.js
+++ b/client/src/Components/CommentContent.style.js
@@ -1,0 +1,31 @@
+import { styled } from 'styled-components';
+
+export const Item = {
+  Content: styled.div`
+    margin-left: 12px;
+  `,
+};
+
+export const Content = {
+  Info: styled.div`
+    width: 100%;
+  `,
+  CreateAt: styled.div`
+    font-size: 12px;
+    color: #737373;
+    font-weight: 400;
+    margin-top: 4px;
+  `,
+};
+
+export const Info = {
+  Name: styled.span`
+    font-size: 14px;
+    font-weight: 700;
+  `,
+  Content: styled.span`
+    margin-left: 6px;
+    font-size: 14px;
+    font-weight: 400;
+  `,
+};

--- a/client/src/Components/CommentEdit.jsx
+++ b/client/src/Components/CommentEdit.jsx
@@ -3,15 +3,24 @@ import { Edit, Btn } from './CommentEdit.style';
 import axios from 'axios';
 
 function CommentEdit({ item, setIsEdit }) {
+  const accessToken = sessionStorage.getItem('token');
   const url = `${import.meta.env.VITE_API_URL}/comments/${item.commentId}`;
   const [commentText, setCommentText] = useState(item.content);
 
   // 댓글 수정 API
   const EditData = () => {
     axios
-      .delete(url, {
-        content: commentText,
-      })
+      .delete(
+        url,
+        {
+          content: commentText,
+        },
+        {
+          headers: {
+            Authorization: accessToken,
+          },
+        }
+      )
       .then((response) => {
         console.log(response.data);
       })

--- a/client/src/Components/CommentEdit.jsx
+++ b/client/src/Components/CommentEdit.jsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+import { Edit, Btn } from './CommentEdit.style';
+import axios from 'axios';
+
+function CommentEdit({ item, setIsEdit }) {
+  const url = `${import.meta.env.VITE_API_URL}/comments/${item.commentId}`;
+  const [commentText, setCommentText] = useState(item.content);
+
+  // 댓글 수정 API
+  const EditData = () => {
+    axios
+      .delete(url, {
+        content: commentText,
+      })
+      .then((response) => {
+        console.log(response.data);
+      })
+      .catch((error) => {
+        throw error;
+      });
+  };
+
+  const handleChange = (e) => {
+    setCommentText(e.target.value);
+  };
+
+  const handleClickCancel = () => {
+    setIsEdit(false);
+  };
+
+  const handleClickEdit = () => {
+    const confirmValue = confirm('정말로 수정하시겠습니까?');
+    if (confirmValue) {
+      EditData();
+      setIsEdit(false);
+    }
+  };
+  return (
+    <Edit.Container>
+      <Edit.Textarea type="text" value={commentText} onChange={handleChange} />
+      <Btn.Container>
+        <Btn.Edit onClick={handleClickEdit}>수정</Btn.Edit>
+        <Btn.Cancel onClick={handleClickCancel}>취소</Btn.Cancel>
+      </Btn.Container>
+    </Edit.Container>
+  );
+}
+
+export default CommentEdit;

--- a/client/src/Components/CommentEdit.style.js
+++ b/client/src/Components/CommentEdit.style.js
@@ -1,0 +1,55 @@
+import { styled } from 'styled-components';
+
+export const Edit = {
+  Container: styled.div`
+    margin-left: 12px;
+    width: 100%;
+  `,
+  Textarea: styled.textarea`
+    border: 1px solid #000;
+    outline: 0;
+    resize: none;
+    min-height: 32px;
+    max-height: 64px;
+    width: 100%;
+    padding-top: 10px;
+    padding-left: 10px;
+    &::-webkit-scrollbar {
+      width: 4px;
+    }
+    &::-webkit-scrollbar-thumb {
+      border-radius: 2px;
+      background: #ccc;
+    }
+  `,
+};
+
+export const Btn = {
+  Container: styled.div`
+    display: flex;
+    justify-content: end;
+  `,
+  Edit: styled.button`
+    border: 0;
+    background-color: #fff;
+    font-size: 14px;
+    color: blue;
+    cursor: pointer;
+    margin-right: 4px;
+
+    &:hover {
+      font-weight: bold;
+    }
+  `,
+  Cancel: styled.button`
+    border: 0;
+    background-color: #fff;
+    font-size: 14px;
+    color: #555;
+    cursor: pointer;
+
+    &:hover {
+      font-weight: bold;
+    }
+  `,
+};

--- a/client/src/Components/CommentEditDelete.jsx
+++ b/client/src/Components/CommentEditDelete.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Btn } from './CommentEditDelete.style';
 import axios from 'axios';
 
-function CommentEditDelete({ commentId, memberId }) {
+function CommentEditDelete({ commentId, memberId, setIsEdit }) {
   // 로그인된 사용자의 멤버아이디를 임시로 지정
   const loginId = 'MEM_1';
 
@@ -29,9 +29,13 @@ function CommentEditDelete({ commentId, memberId }) {
     }
   };
 
+  const handleClickEdit = () => {
+    setIsEdit(true);
+  };
+
   return (
     <Btn.Container>
-      <Btn.Edit>수정</Btn.Edit>
+      <Btn.Edit onClick={handleClickEdit}>수정</Btn.Edit>
       <Btn.Delete onClick={handleClickDelete}>삭제</Btn.Delete>
     </Btn.Container>
   );

--- a/client/src/Components/CommentEditDelete.jsx
+++ b/client/src/Components/CommentEditDelete.jsx
@@ -3,15 +3,19 @@ import { Btn } from './CommentEditDelete.style';
 import axios from 'axios';
 
 function CommentEditDelete({ commentId, memberId, setIsEdit }) {
-  // 로그인된 사용자의 멤버아이디를 임시로 지정
-  const loginId = 'MEM_1';
-
+  // 로그인된 사용자의 멤버아이디
+  const loginId = sessionStorage.getItem('memberId');
+  const accessToken = sessionStorage.getItem('token');
   const url = `${import.meta.env.VITE_API_URL}/comments/${commentId}`;
 
   // 댓글 삭제 API
   const DeletData = () => {
     axios
-      .delete(url)
+      .delete(url, {
+        headers: {
+          Authorization: accessToken,
+        },
+      })
       .then((response) => {
         console.log(response.data);
       })

--- a/client/src/Components/CommentEditDelete.jsx
+++ b/client/src/Components/CommentEditDelete.jsx
@@ -1,14 +1,14 @@
 import React from 'react';
-import { AuthorityBtn } from './PostEditDelete.style';
+import { Btn } from './CommentEditDelete.style';
 import axios from 'axios';
 
-function PostEditDelete({ postId, memberId }) {
+function CommentEditDelete({ commentId, memberId }) {
   // 로그인된 사용자의 멤버아이디를 임시로 지정
   const loginId = 'MEM_1';
 
-  const url = `${import.meta.env.VITE_API_URL}/posts/${postId}`;
+  const url = `${import.meta.env.VITE_API_URL}/comments/${commentId}`;
 
-  // 게시글 삭제 API
+  // 댓글 삭제 API
   const DeletData = () => {
     axios
       .delete(url)
@@ -22,6 +22,7 @@ function PostEditDelete({ postId, memberId }) {
 
   const handleClickDelete = () => {
     const confirmValue = confirm('정말로 삭제하시겠습니까?');
+
     // 로그인된 사용자와 게시글의 작성자가 같으면 삭제요청가능
     if (memberId === loginId && confirmValue) {
       DeletData();
@@ -29,13 +30,11 @@ function PostEditDelete({ postId, memberId }) {
   };
 
   return (
-    <AuthorityBtn.Container>
-      <AuthorityBtn.Edit>수정</AuthorityBtn.Edit>
-      <AuthorityBtn.Delete onClick={handleClickDelete}>
-        삭제
-      </AuthorityBtn.Delete>
-    </AuthorityBtn.Container>
+    <Btn.Container>
+      <Btn.Edit>수정</Btn.Edit>
+      <Btn.Delete onClick={handleClickDelete}>삭제</Btn.Delete>
+    </Btn.Container>
   );
 }
 
-export default PostEditDelete;
+export default CommentEditDelete;

--- a/client/src/Components/CommentEditDelete.style.js
+++ b/client/src/Components/CommentEditDelete.style.js
@@ -1,0 +1,32 @@
+import { styled } from 'styled-components';
+
+export const Btn = {
+  Container: styled.div`
+    display: inline-block;
+    margin-left: 10px;
+  `,
+  Edit: styled.button`
+    border: 0;
+    background-color: #fff;
+    font-size: 12px;
+    color: #555;
+    cursor: pointer;
+    margin-right: 4px;
+
+    &:hover {
+      color: #555;
+      font-weight: bold;
+    }
+  `,
+  Delete: styled.button`
+    border: 0;
+    background-color: #fff;
+    font-size: 12px;
+    color: #f21f1f;
+    cursor: pointer;
+
+    &:hover {
+      font-weight: bold;
+    }
+  `,
+};

--- a/client/src/Components/PostComment.jsx
+++ b/client/src/Components/PostComment.jsx
@@ -1,20 +1,20 @@
-import React from "react";
-import PostCommentItem from "./PostCommentItem";
-import { CommentContainer,CommentList } from "./PostComment.style";
+import React from 'react';
+import PostCommentItem from './PostCommentItem';
+import { CommentContainer, CommentList } from './PostComment.style';
 
-function PostComment ({ comments }){
-
-  //댓글리스트 pops로 받아오기
-  console.log(comments)
+function PostComment({ comments }) {
   return (
     <CommentContainer>
       <CommentList>
         <ul>
-          {comments&&comments.map( item => <PostCommentItem key={item.memberId} item={item}/>)}
+          {comments &&
+            comments.map((item) => (
+              <PostCommentItem key={item.memberId} item={item} />
+            ))}
         </ul>
       </CommentList>
     </CommentContainer>
-  )
+  );
 }
 
 export default PostComment;

--- a/client/src/Components/PostCommentInput.jsx
+++ b/client/src/Components/PostCommentInput.jsx
@@ -3,21 +3,30 @@ import { InputContainer } from './PostCommentInput.style';
 import axios from 'axios';
 
 function PostCommentInput({ postId }) {
+  const accessToken = sessionStorage.getItem('token');
   const url = `${import.meta.env.VITE_API_URL}/comments`;
   const [commentText, setCommentText] = useState('');
 
-  // 로그인된 사용자의 멤버아이디를 임시로 지정
-  const loginId = 'MEM_1';
+  // 로그인된 사용자의 멤버아이디
+  const loginId = sessionStorage.getItem('memberId');
 
   //댓글작성 api
   const postData = () => {
     if (commentText !== '') {
       axios
-        .post(url, {
-          memberId: loginId,
-          postsId: postId,
-          content: commentText,
-        })
+        .post(
+          url,
+          {
+            memberId: loginId,
+            postsId: postId,
+            content: commentText,
+          },
+          {
+            headers: {
+              Authorization: accessToken,
+            },
+          }
+        )
         .then((response) => {
           console.log(response.data);
         })

--- a/client/src/Components/PostCommentInput.jsx
+++ b/client/src/Components/PostCommentInput.jsx
@@ -1,32 +1,35 @@
-import React ,{useRef, useState} from "react";
-import { InputContainer } from "./PostCommentInput.style";
-import axios from "axios";
+import React, { useRef, useState } from 'react';
+import { InputContainer } from './PostCommentInput.style';
+import axios from 'axios';
 
-function PostCommentInput ({postId}){
-
-  const url = `${import.meta.env.VITE_API_URL}/comments`
-  const [commentText, setCommentText] = useState('')
+function PostCommentInput({ postId }) {
+  const url = `${import.meta.env.VITE_API_URL}/comments`;
+  const [commentText, setCommentText] = useState('');
 
   // 로그인된 사용자의 멤버아이디를 임시로 지정
-  const loginId = "MEM_1"
+  const loginId = 'MEM_1';
 
   //댓글작성 api
   const postData = () => {
-    axios.post(url, {
-      memberId : loginId,
-      postsId : postId,
-      content: commentText
-    })
-    .then((response) => {
-      console.log(response.data)
-    })
-    .catch((error) => {throw error;});
-  }
-
+    if (commentText !== '') {
+      axios
+        .post(url, {
+          memberId: loginId,
+          postsId: postId,
+          content: commentText,
+        })
+        .then((response) => {
+          console.log(response.data);
+        })
+        .catch((error) => {
+          throw error;
+        });
+    }
+  };
 
   const handleClick = () => {
     postData();
-  }
+  };
 
   const textarea = useRef();
 
@@ -34,24 +37,34 @@ function PostCommentInput ({postId}){
     setCommentText(e.target.value);
     textarea.current.style.height = 'auto';
     textarea.current.style.height = textarea.current.scrollHeight + 'px';
-  }
+  };
 
   return (
     <InputContainer>
-      <img src={"https://cdn.pixabay.com/photo/2016/03/26/22/13/man-1281562_1280.jpg"/* 로그인된 멤버의 프로필이미지*/} alt="내 프로필이미지" />
+      <img
+        src={
+          'https://cdn.pixabay.com/photo/2016/03/26/22/13/man-1281562_1280.jpg' /* 로그인된 멤버의 프로필이미지*/
+        }
+        alt="내 프로필이미지"
+      />
       <div>
-        <textarea 
-          ref={textarea} 
-          type="text" 
-          placeholder="댓글달기" 
-          rows={1} 
-          onChange={handleResizeHeight} 
-          value={commentText}/>
+        <textarea
+          ref={textarea}
+          type="text"
+          placeholder="댓글달기"
+          rows={1}
+          onChange={handleResizeHeight}
+          value={commentText}
+        />
       </div>
-      <button onClick={handleClick}>게시</button>
+      <button
+        onClick={handleClick}
+        disabled={commentText !== '' ? false : true}
+      >
+        게시
+      </button>
     </InputContainer>
-  )
-
+  );
 }
 
 export default PostCommentInput;

--- a/client/src/Components/PostCommentInput.style.js
+++ b/client/src/Components/PostCommentInput.style.js
@@ -1,4 +1,4 @@
-import { styled } from "styled-components";
+import { styled } from 'styled-components';
 
 export const InputContainer = styled.div`
   width: 530px;
@@ -50,6 +50,11 @@ export const InputContainer = styled.div`
 
     &:hover {
       color: #737373;
+    }
+
+    &:disabled {
+      color: #dbdbdb;
+      cursor: no-drop;
     }
   }
 `;

--- a/client/src/Components/PostCommentItem.jsx
+++ b/client/src/Components/PostCommentItem.jsx
@@ -1,30 +1,19 @@
-import React from 'react';
-import { Item, Content, Info } from './PostCommentItem.style';
-import CommentEditDelete from './CommentEditDelete';
+import React, { useState } from 'react';
+import { Item } from './PostCommentItem.style';
+import CommentContent from './CommentContent';
+import CommentEdit from './CommentEdit';
 
 function PostCommentItem({ item }) {
-  // 로그인된 사용자의 멤버아이디를 임시로 지정
-  const loginId = 'MEM_1';
+  const [isEdit, setIsEdit] = useState(false);
 
   return (
     <Item.Container>
       <Item.Profile src={item.userImageUrl} alt="작성자 프로필" />
-      <Item.Content>
-        <Content.Info>
-          <Info.Name>{item.userName}</Info.Name>
-          <Info.Content>
-            {/*item.content*/}가장긴댓ㅇ르 사용했을때는 어떻게 보일까요 가장 긴
-            탟ㅅ을 사용했을때는 어떻ㄱ세 표시가 될까요
-          </Info.Content>
-          {loginId === item.memberId ? (
-            <CommentEditDelete
-              commentId={item.commentId}
-              memberId={item.memberId}
-            />
-          ) : undefined}
-        </Content.Info>
-        <Content.CreateAt>{item.createAt}</Content.CreateAt>
-      </Item.Content>
+      {isEdit ? (
+        <CommentEdit item={item} setIsEdit={setIsEdit} />
+      ) : (
+        <CommentContent item={item} setIsEdit={setIsEdit} />
+      )}
     </Item.Container>
   );
 }

--- a/client/src/Components/PostCommentItem.jsx
+++ b/client/src/Components/PostCommentItem.jsx
@@ -1,21 +1,32 @@
-import React from "react";
-import { ItemList, ItemContent } from "./PostCommentItem.style";
+import React from 'react';
+import { Item, Content, Info } from './PostCommentItem.style';
+import CommentEditDelete from './CommentEditDelete';
 
-function PostCommentItem({item}){
+function PostCommentItem({ item }) {
+  // 로그인된 사용자의 멤버아이디를 임시로 지정
+  const loginId = 'MEM_1';
 
   return (
-    <ItemList>
-      <img src={item.userImageUrl} alt="작성자 프로필" />
-      <ItemContent>
-        <div>
-          <span className="name">{item.userName}</span>
-          <span className="content">{/*item.content*/}가장긴댓ㅇ르 사용했을때는 어떻게 보일까요 가장 긴 탟ㅅ을 사용했을때는 어떻ㄱ세 표시가 될까요</span> 
-        </div>
-        <div className="createAt">{item.createAt}</div> 
-      </ItemContent>
-    </ItemList>
-  )
-
+    <Item.Container>
+      <Item.Profile src={item.userImageUrl} alt="작성자 프로필" />
+      <Item.Content>
+        <Content.Info>
+          <Info.Name>{item.userName}</Info.Name>
+          <Info.Content>
+            {/*item.content*/}가장긴댓ㅇ르 사용했을때는 어떻게 보일까요 가장 긴
+            탟ㅅ을 사용했을때는 어떻ㄱ세 표시가 될까요
+          </Info.Content>
+          {loginId === item.memberId ? (
+            <CommentEditDelete
+              commentId={item.commentId}
+              memberId={item.memberId}
+            />
+          ) : undefined}
+        </Content.Info>
+        <Content.CreateAt>{item.createAt}</Content.CreateAt>
+      </Item.Content>
+    </Item.Container>
+  );
 }
 
 export default PostCommentItem;

--- a/client/src/Components/PostCommentItem.style.js
+++ b/client/src/Components/PostCommentItem.style.js
@@ -1,37 +1,43 @@
-import { styled } from "styled-components";
+import { styled } from 'styled-components';
 
-export const ItemList = styled.li`
-  width: 100%;
-  display: flex;
-  margin-bottom: 18px;
-
-  > img {
+export const Item = {
+  Container: styled.li`
+    width: 100%;
+    display: flex;
+    margin-bottom: 18px;
+  `,
+  Profile: styled.img`
     width: 32px;
     height: 32px;
     border-radius: 70%;
     object-fit: cover;
     aspect-ratio: 1/1;
-  }
-`;
+  `,
+  Content: styled.div`
+    margin-left: 12px;
+  `,
+};
 
-export const ItemContent = styled.div`
-  margin-left: 12px;
-
-  > div > .name {
-    font-size: 14px;
-    font-weight: 700;
-  }
-
-  > div > .content {
-    margin-left: 6px;
-    font-size: 14px;
-    font-weight: 400;
-  }
-
-  > .createAt {
+export const Content = {
+  Info: styled.div`
+    width: 100%;
+  `,
+  CreateAt: styled.div`
     font-size: 12px;
     color: #737373;
     font-weight: 400;
     margin-top: 4px;
-  }
-`;
+  `,
+};
+
+export const Info = {
+  Name: styled.span`
+    font-size: 14px;
+    font-weight: 700;
+  `,
+  Content: styled.span`
+    margin-left: 6px;
+    font-size: 14px;
+    font-weight: 400;
+  `,
+};

--- a/client/src/Components/PostCommentItem.style.js
+++ b/client/src/Components/PostCommentItem.style.js
@@ -13,31 +13,4 @@ export const Item = {
     object-fit: cover;
     aspect-ratio: 1/1;
   `,
-  Content: styled.div`
-    margin-left: 12px;
-  `,
-};
-
-export const Content = {
-  Info: styled.div`
-    width: 100%;
-  `,
-  CreateAt: styled.div`
-    font-size: 12px;
-    color: #737373;
-    font-weight: 400;
-    margin-top: 4px;
-  `,
-};
-
-export const Info = {
-  Name: styled.span`
-    font-size: 14px;
-    font-weight: 700;
-  `,
-  Content: styled.span`
-    margin-left: 6px;
-    font-size: 14px;
-    font-weight: 400;
-  `,
 };

--- a/client/src/Components/PostContent.jsx
+++ b/client/src/Components/PostContent.jsx
@@ -1,25 +1,45 @@
-import React from "react";
-import { PostContainer, Author,Title, Text,Profile, AuthorName } from "./PostContent.style";
+import React from 'react';
+import {
+  PostContainer,
+  Author,
+  Title,
+  Text,
+  AuthorInfo,
+} from './PostContent.style';
 import { dummyText } from '../assets/mock/dummyData.js';
+import PostEditDelete from './PostEditDelete';
 
-
-
-function PostContent ({ data }){
+function PostContent({ data }) {
+  // 로그인된 사용자의 멤버아이디를 임시로 지정
+  const loginId = 'MEM_1';
 
   return (
     <PostContainer>
       <Author>
-        <Profile to={`/members/${data.memberId}`}>
-          <img src={data.userImageUrl} alt="" />
-        </Profile>
-        <AuthorName to={`/members/${data.memberId}`}>{data.userName}</AuthorName>
-        <div className="createdAt">{data.createdAt}</div>
+        <AuthorInfo.Container>
+          <AuthorInfo.Profile to={`/members/${data.memberId}`}>
+            <img src={data.userImageUrl} alt="" />
+          </AuthorInfo.Profile>
+          <AuthorInfo.AuthorName to={`/members/${data.memberId}`}>
+            {data.userName}
+          </AuthorInfo.AuthorName>
+          <AuthorInfo.CreateAt>{data.createdAt}</AuthorInfo.CreateAt>
+        </AuthorInfo.Container>
+
+        {
+          /* 본인이 작성한 게시물에 대해서만 수정/삭제 버튼을 표시 */
+          loginId === data.memberId ? (
+            <PostEditDelete postId={data.postId} memberId={data.memberId} />
+          ) : undefined
+        }
       </Author>
       <Title className="title">{data.title}</Title>
-      <Text className="text">{/*data.content*/}{dummyText}</Text>
+      <Text className="text">
+        {/*data.content*/}
+        {dummyText}
+      </Text>
     </PostContainer>
-
-  )
+  );
 }
 
 export default PostContent;

--- a/client/src/Components/PostContent.jsx
+++ b/client/src/Components/PostContent.jsx
@@ -6,12 +6,11 @@ import {
   Text,
   AuthorInfo,
 } from './PostContent.style';
-import { dummyText } from '../assets/mock/dummyData.js';
 import PostEditDelete from './PostEditDelete';
 
 function PostContent({ data }) {
-  // 로그인된 사용자의 멤버아이디를 임시로 지정
-  const loginId = 'MEM_1';
+  // 로그인된 사용자의 멤버아이디
+  const loginId = sessionStorage.getItem('memberId');
 
   return (
     <PostContainer>
@@ -34,10 +33,7 @@ function PostContent({ data }) {
         }
       </Author>
       <Title className="title">{data.title}</Title>
-      <Text className="text">
-        {/*data.content*/}
-        {dummyText}
-      </Text>
+      <Text className="text">{data.content}</Text>
     </PostContainer>
   );
 }

--- a/client/src/Components/PostContent.style.js
+++ b/client/src/Components/PostContent.style.js
@@ -1,5 +1,5 @@
-import { styled } from "styled-components";
-import { Link } from "react-router-dom";
+import { styled } from 'styled-components';
+import { Link } from 'react-router-dom';
 
 export const PostContainer = styled.section`
   width: 530px;
@@ -16,33 +16,41 @@ export const Author = styled.div`
   height: 32px;
   display: flex;
   align-items: center;
+  justify-content: space-between;
+`;
 
-  > .createdAt {
+export const AuthorInfo = {
+  Container: styled.div`
+    display: flex;
+    align-items: center;
+  `,
+  CreateAt: styled.div`
     font-size: 16px;
     font-weight: normal;
     color: #737373;
     margin-left: 10px;
-  }
-`;
+  `,
+  Profile: styled(Link)`
+    cursor: pointer;
+    display: flex;
+    align-items: center;
 
-export const Profile = styled(Link)`
-  cursor: pointer;
-  > img {
-    width: 32px;
-    border-radius: 70%;
-    object-fit: cover;
-    aspect-ratio: 1/1;
-  }
-`;
-
-export const AuthorName = styled(Link)`
-  font-size: 16px;
-  font-weight: bold;
-  color: #000;
-  margin-left: 12px;
-  text-decoration: none;
-  cursor: pointer;
-`;
+    > img {
+      width: 32px;
+      border-radius: 70%;
+      object-fit: cover;
+      aspect-ratio: 1/1;
+    }
+  `,
+  AuthorName: styled(Link)`
+    font-size: 16px;
+    font-weight: bold;
+    color: #000;
+    margin-left: 12px;
+    text-decoration: none;
+    cursor: pointer;
+  `,
+};
 
 export const Title = styled.div`
   font-size: 18px;

--- a/client/src/Components/PostDetailBox.jsx
+++ b/client/src/Components/PostDetailBox.jsx
@@ -9,12 +9,17 @@ function PostDatailBox({ postId }) {
   const url = `${import.meta.env.VITE_API_URL}/posts/${postId}`;
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(false);
+  const accessToken = sessionStorage.getItem('token');
 
   // GET API
   const getData = () => {
     setLoading(true);
     axios
-      .get(url)
+      .get(url, {
+        headers: {
+          Authorization: accessToken,
+        },
+      })
       .then((response) => {
         setData(response.data);
         setLoading(false);

--- a/client/src/Components/PostDetailBox.jsx
+++ b/client/src/Components/PostDetailBox.jsx
@@ -36,7 +36,7 @@ function PostDatailBox({ postId }) {
       <PostBody>
         <PostContent data={data} />
         <PostComment comments={data.comments} />
-        <PostCommentInput postId={postId} />{' '}
+        <PostCommentInput postId={postId} />
         {/*로그인된 멤버의 프로필 prop 전달 */}
       </PostBody>
     </Container>

--- a/client/src/Components/PostDetailBox.jsx
+++ b/client/src/Components/PostDetailBox.jsx
@@ -1,45 +1,46 @@
-import React, {useState,useEffect} from "react";
-import {  Container, PostImg, PostBody } from "./PostDetailBox.style";
-import PostContent from "./PostContent";
-import PostComment from "./PostComment";
-import PostCommentInput from "./PostCommentInput";
-import axios from "axios";
+import React, { useState, useEffect } from 'react';
+import { Container, PostImg, PostBody } from './PostDetailBox.style';
+import PostContent from './PostContent';
+import PostComment from './PostComment';
+import PostCommentInput from './PostCommentInput';
+import axios from 'axios';
 
-function PostDatailBox ({ postId }){
-
-  const url = `${import.meta.env.VITE_API_URL}/posts/${postId}`
+function PostDatailBox({ postId }) {
+  const url = `${import.meta.env.VITE_API_URL}/posts/${postId}`;
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(false);
 
   // GET API
   const getData = () => {
-    setLoading(true)
-    axios.get(url)
-        .then((response) => {
-          setData(response.data)
-          setLoading(false)
-        })
-        .catch((error) => {throw error;});
-  }
+    setLoading(true);
+    axios
+      .get(url)
+      .then((response) => {
+        setData(response.data);
+        setLoading(false);
+      })
+      .catch((error) => {
+        throw error;
+      });
+  };
 
   useEffect(() => {
     getData();
   }, []);
-  
 
   return (
-      <Container>
-        <PostImg>
-          <img src={data.imageUrl} alt="게시글 이미지" />
-        </PostImg>
-        <PostBody>
-          <PostContent data={data}/>
-          <PostComment comments={data.comments}/>
-          <PostCommentInput postId={postId}/> {/*로그인된 멤버의 프로필 prop 전달 */}
-        </PostBody>
-      </Container>
-  )
-
+    <Container>
+      <PostImg>
+        <img src={data.imageUrl} alt="게시글 이미지" />
+      </PostImg>
+      <PostBody>
+        <PostContent data={data} />
+        <PostComment comments={data.comments} />
+        <PostCommentInput postId={postId} />{' '}
+        {/*로그인된 멤버의 프로필 prop 전달 */}
+      </PostBody>
+    </Container>
+  );
 }
 
 export default PostDatailBox;

--- a/client/src/Components/PostEditDelete.jsx
+++ b/client/src/Components/PostEditDelete.jsx
@@ -3,15 +3,20 @@ import { AuthorityBtn } from './PostEditDelete.style';
 import axios from 'axios';
 
 function PostEditDelete({ postId, memberId }) {
-  // 로그인된 사용자의 멤버아이디를 임시로 지정
-  const loginId = 'MEM_1';
+  // 로그인된 사용자의 멤버아이디
+  const loginId = sessionStorage.getItem('memberId');
+  const accessToken = sessionStorage.getItem('token');
 
   const url = `${import.meta.env.VITE_API_URL}/posts/${postId}`;
 
   // 게시글 삭제 API
   const DeletData = () => {
     axios
-      .delete(url)
+      .delete(url, {
+        headers: {
+          Authorization: accessToken,
+        },
+      })
       .then((response) => {
         console.log(response.data);
       })

--- a/client/src/Components/PostEditDelete.jsx
+++ b/client/src/Components/PostEditDelete.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { AuthorityBtn } from './PostEditDelete.style';
+import axios from 'axios';
+
+function PostEditDelete({ postId, memberId }) {
+  // 로그인된 사용자의 멤버아이디를 임시로 지정
+  const loginId = 'MEM_1';
+
+  const url = `${import.meta.env.VITE_API_URL}/posts/${postId}`;
+
+  // 게시글 삭제 API
+  const DeletData = () => {
+    axios
+      .delete(url)
+      .then((response) => {
+        console.log(response.data);
+      })
+      .catch((error) => {
+        throw error;
+      });
+  };
+
+  const handleClickDelete = () => {
+    // 로그인된 사용자와 게시글의 작성자가 같으면 삭제요청가능
+    if (memberId === loginId) {
+      DeletData();
+    }
+  };
+
+  return (
+    <AuthorityBtn.Container>
+      <AuthorityBtn.Edit>수정</AuthorityBtn.Edit>
+      <AuthorityBtn.Delete onClick={handleClickDelete}>
+        삭제
+      </AuthorityBtn.Delete>
+    </AuthorityBtn.Container>
+  );
+}
+
+export default PostEditDelete;

--- a/client/src/Components/PostEditDelete.style.js
+++ b/client/src/Components/PostEditDelete.style.js
@@ -1,0 +1,31 @@
+import { styled } from 'styled-components';
+
+export const AuthorityBtn = {
+  Container: styled.div`
+    margin-right: 20px;
+  `,
+  Edit: styled.button`
+    border: 0;
+    background-color: #fff;
+    font-size: 14px;
+    color: #555;
+    cursor: pointer;
+    margin-right: 10px;
+
+    &:hover {
+      color: #555;
+      font-weight: bold;
+    }
+  `,
+  Delete: styled.button`
+    border: 0;
+    background-color: #fff;
+    font-size: 14px;
+    color: #f21f1f;
+    cursor: pointer;
+
+    &:hover {
+      font-weight: bold;
+    }
+  `,
+};

--- a/client/src/Components/ShareBoard.jsx
+++ b/client/src/Components/ShareBoard.jsx
@@ -1,55 +1,65 @@
-import React, {useCallback, useState, useEffect} from 'react';
+import React, { useState, useEffect } from 'react';
 import { BoardBox, Title, CardList, Btn } from './ShareBoard.style.js';
 import Carditem from './Carditem.jsx';
-import axios from "axios";
+import axios from 'axios';
 
-
-function ShareBoard ({ type }){
-
+function ShareBoard({ type }) {
   const MESSAGE = {
-    TITLE_WORKOUT: "오늘은 무슨 운동을 하셨나요?",
-    TITLE_DIET: "오늘은 무슨 식단을 하셨나요?",
-    BTN_WORKOUT: "운동 게시글 만들기",
-    BTN_DIET: "식단 게시글 만들기" 
-  }
+    TITLE_WORKOUT: '오늘은 무슨 운동을 하셨나요?',
+    TITLE_DIET: '오늘은 무슨 식단을 하셨나요?',
+    BTN_WORKOUT: '운동 게시글 만들기',
+    BTN_DIET: '식단 게시글 만들기',
+  };
 
-
-  const url = `${import.meta.env.VITE_API_URL}/posts`
+  const accessToken = sessionStorage.getItem('token');
+  const url = `${import.meta.env.VITE_API_URL}/posts`;
 
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(false);
 
   // GET API
   const getData = () => {
-    setLoading(true)
-    axios.get(url, {params: {category: type}})
-        .then((response) => {
-          setData(response.data)
-          setLoading(false)
-        })
-        .catch((error) => {throw error;});
-  }
+    setLoading(true);
+    axios
+      .get(
+        url,
+        { params: { category: type } },
+        {
+          headers: {
+            Authorization: accessToken,
+          },
+        }
+      )
+      .then((response) => {
+        setData(response.data);
+        setLoading(false);
+      })
+      .catch((error) => {
+        throw error;
+      });
+  };
 
   useEffect(() => {
-    getData()
+    getData();
   }, []);
 
-  
   return (
     <BoardBox>
       <Title>
         <h1>
-          {type === "workout" ? MESSAGE.TITLE_WORKOUT : MESSAGE.TITLE_DIET}
+          {type === 'workout' ? MESSAGE.TITLE_WORKOUT : MESSAGE.TITLE_DIET}
         </h1>
-        <Btn to={type === "workout" ? "/create/workout" : "/create/diet"}>
-          {type === "workout" ? MESSAGE.BTN_WORKOUT : MESSAGE.BTN_DIET}
+        <Btn to={type === 'workout' ? '/create/workout' : '/create/diet'}>
+          {type === 'workout' ? MESSAGE.BTN_WORKOUT : MESSAGE.BTN_DIET}
         </Btn>
       </Title>
       <CardList>
-        {data && data.posts && data.posts.map(item => <Carditem key={item.postId} item={item}/>)}
+        {data &&
+          data.posts &&
+          data.posts.map((item) => <Carditem key={item.postId} item={item} />)}
       </CardList>
     </BoardBox>
-  )
+  );
 }
 
 export default ShareBoard;


### PR DESCRIPTION
## 구현 내용

- 로그인 된 사용자의 memberId를 기준으로 본인이 작성한 게시글, 댓글일 경우 수정/삭제 버튼을 표시하고 그렇지 않을 경우 수정/삭제 버튼을 표시하지 않도록 구현하였습니다.

#### 구현된 기능 목록

- [x] 게시글 삭제 기능
- [x] 댓글 수정 기능
- [x] 댓글 삭제 기능

## 이후 진행사항 공유

- 게시글 수정의 경우 createWorkout, createDiet의 컴포넌트를 재사용하고자 합니다. 작성페이지 이미지 업로드 구현이 완료 된 후 해당 파트 담당자와 추가 논의를 통해 구현 예정입니다.
- 현재 props 를 통해 상태가 관리되도록 구현되어있습니다. 댓글 수정, 삭제 수행 후 리렌더링을 시키기위해 리덕스를 적용 시킬 예정입니다.

#### 이후 진행 예정인 작업 목록

- [ ] 게시글 수정 기능
- [ ] 게시글 삭제 시 리다이렉트 경로 설정
- [ ] 리덕스 툴킷 적용
- [ ] 게시글 수정, 댓글 수정, 댓글 삭제 시 리렌더링
- [ ] 무한스크롤