### PR TITLE
[FE] 닉네임 중복 확인 로직 추가

### DIFF
--- a/client/src/Components/Modal.style.js
+++ b/client/src/Components/Modal.style.js
@@ -67,7 +67,7 @@ export const DeleteModalContainer = styled.section`
 export const ModalButton = styled.button`
   width: 140px;
   height: 50px;
-  border: none;
+  border: 1px solid black;
   color: white;
   background-color: black;
   border-radius: 6px;
@@ -216,4 +216,9 @@ export const UploadArea = styled.section`
   justify-content: center;
   align-items: center;
   cursor: pointer;
+`;
+
+export const ModalInputContainer = styled.section`
+  display: flex;
+  align-items: center;
 `;


### PR DESCRIPTION
닉네임 변경 시 중복 여부 확인 로직을 추가한다.

- [x] 유효성 검증이 통과하면 중복 확인 버튼이 활성화된다.
- [x] 중복 확인 버튼을 클릭하면 서버로 요청을 보내 해당 닉네임이 중복되는지 여부를 확인한다.
- [x] 중복되지 않는 닉네임일 경우 변경 버튼이 활성화된다.
- [x] 중복되는 닉네임일 경우 변경 버튼이 활성화되지 않는다.
- [x] 중복이 확인된 후 닉네임 입력값의 변경을 시도하면 변경 버튼이 비활성화된다.