### PR TITLE
[FE] 잘못된 페이지 접근 시 예외처리를 위한 NotFoundPage 구현

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -20,6 +20,7 @@ import CrewingDetail from './Pages/CrewingDetail';
 import Settings from './Pages/Settings';
 import PrivateRoute from './utils/PrivateRoute';
 import PublicRoute from './utils/PublicRoute';
+import NotFoundPage from './Components/NotFoundPage';
 const GlobalStyle = createGlobalStyle`
 * {
   box-sizing: border-box;
@@ -151,6 +152,14 @@ function App() {
               element={
                 <PrivateRoute>
                   <Settings />
+                </PrivateRoute>
+              }
+            />
+            <Route
+              path="*"
+              element={
+                <PrivateRoute>
+                  <NotFoundPage />
                 </PrivateRoute>
               }
             />

--- a/client/src/Components/NotFoundPage.jsx
+++ b/client/src/Components/NotFoundPage.jsx
@@ -1,0 +1,36 @@
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  PageContainer,
+  MessageEmoji,
+  MessageHeading,
+  MessageSubHeading,
+  MessageDetails,
+} from './NotFoundPage.style';
+import { faFaceSurprise } from '@fortawesome/free-regular-svg-icons';
+import gif from '../assets/loading-spinner.gif';
+
+const NotFoundPage = () => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    setTimeout(() => {
+      navigate(-1);
+    }, 3000);
+  }, [navigate]);
+
+  return (
+    <PageContainer>
+      <MessageEmoji icon={faFaceSurprise} />
+      <MessageHeading>엥?</MessageHeading>
+      <MessageSubHeading>존재하지 않는 페이지에요!</MessageSubHeading>
+      <MessageDetails>
+        이미 삭제되었거나, 잘못된 정보에 접근하고 있는 것 같아요.
+      </MessageDetails>
+      <img style={{ width: '50px' }} src={gif} alt="loading-spinner" />
+      <MessageDetails>잠시 후에 이전 페이지로 이동할게요.</MessageDetails>
+    </PageContainer>
+  );
+};
+
+export default NotFoundPage;

--- a/client/src/Components/NotFoundPage.style.js
+++ b/client/src/Components/NotFoundPage.style.js
@@ -1,0 +1,37 @@
+import { styled } from 'styled-components';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+export const PageContainer = styled.section`
+  width: 100vw;
+  height: 100vh;
+  position: fixed;
+  z-index: 1000;
+  background-color: white;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  left: 0;
+  top: 0;
+`;
+
+export const MessageEmoji = styled(FontAwesomeIcon)`
+  width: 100px;
+  height: 100px;
+  margin-bottom: 30px;
+`;
+
+export const MessageHeading = styled.section`
+  font-size: 52px;
+  font-weight: bold;
+  margin-bottom: 10px;
+`;
+
+export const MessageSubHeading = styled.section`
+  font-size: 25px;
+  margin-bottom: 15px;
+`;
+
+export const MessageDetails = styled.section`
+  color: #c5c5c5;
+`;

--- a/client/src/Components/PostDetailPageBox.jsx
+++ b/client/src/Components/PostDetailPageBox.jsx
@@ -1,0 +1,92 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { Container, PostImg, PostBody } from './PostDetailBox.style';
+import PostContent from './PostContent';
+import PostComment from './PostComment';
+import PostCommentInput from './PostCommentInput';
+import { useDispatch, useSelector } from 'react-redux';
+import axios from 'axios';
+import postDataSlice from '../redux/reducers/postDataSlice';
+import useNotFoundPage from '../utils/hooks/useNotFoundPage';
+
+function PostDetailPageBox({ postId, type }) {
+  console.log('리렌더링 확인');
+  const [isLoading, setIsLoading] = useState(true);
+  const [isEdit, setIsEdit] = useState(false);
+  const { notFound, NotFoundPage, handleNotFoundErrors } = useNotFoundPage();
+  const scrollRef = useRef(null);
+
+  // 댓글 작성 시 댓글창 스크롤업
+  const scrollToTop = () => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = 0;
+    }
+  };
+
+  let url = '';
+
+  if (type === 'crewing') {
+    url = `${import.meta.env.VITE_API_URL}/crewings/${postId}`;
+  } else if (type === 'share') {
+    url = `${import.meta.env.VITE_API_URL}/posts/${postId}`;
+  }
+
+  const accessToken = sessionStorage.getItem('authToken');
+  const dispatch = useDispatch();
+
+  const update = () => {
+    axios
+      .get(url, {
+        headers: {
+          Authorization: accessToken,
+        },
+      })
+      .then((response) => {
+        dispatch(postDataSlice.actions.update(response.data.data));
+        setIsLoading(false);
+      })
+      .catch((error) => {
+        handleNotFoundErrors(error);
+        throw error;
+      });
+  };
+
+  useEffect(() => {
+    update();
+  }, []);
+
+  const data = useSelector((state) => state.postData.data);
+
+  if (notFound) {
+    return <NotFoundPage />;
+  }
+
+  if (!isLoading) {
+    return (
+      <Container>
+        <PostImg>
+          <img src={data && data.imageUrl} alt="게시글 이미지" />
+        </PostImg>
+        <PostBody>
+          <PostContent
+            data={data}
+            type={type}
+            isEdit={isEdit}
+            setIsEdit={setIsEdit}
+          />
+          {isEdit ? undefined : (
+            <PostComment data={data} type={type} scrollRef={scrollRef} />
+          )}
+          {isEdit ? undefined : (
+            <PostCommentInput
+              data={data}
+              type={type}
+              scrollToTop={scrollToTop}
+            />
+          )}
+        </PostBody>
+      </Container>
+    );
+  }
+}
+
+export default PostDetailPageBox;

--- a/client/src/Pages/CrewingDetail.jsx
+++ b/client/src/Pages/CrewingDetail.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Main, Container } from './CrewingDetail.style';
-import PostDatailBox from '../Components/PostDetailBox.jsx';
+import PostDetailPageBox from '../Components/PostDetailPageBox';
 import { useParams } from 'react-router-dom';
 import Nav from '../Components/Nav';
 
@@ -12,7 +12,7 @@ function CrewingDetail() {
       <Nav />
       <Main>
         <Container>
-          <PostDatailBox postId={postId} type={'crewing'} />
+          <PostDetailPageBox postId={postId} type={'crewing'} />
         </Container>
       </Main>
     </>

--- a/client/src/Pages/PostDetail.jsx
+++ b/client/src/Pages/PostDetail.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Main, Container } from './PostDetail.style';
-import PostDatailBox from '../Components/PostDetailBox.jsx';
+import PostDetailPageBox from '../Components/PostDetailPageBox';
 import { useParams } from 'react-router-dom';
 import Nav from '../Components/Nav';
 
@@ -12,7 +12,7 @@ function PostDetail() {
       <Nav />
       <Main>
         <Container>
-          <PostDatailBox postId={postId} type={'share'} />
+          <PostDetailPageBox postId={postId} type={'share'} />
         </Container>
       </Main>
     </>

--- a/client/src/Pages/UserProfile.jsx
+++ b/client/src/Pages/UserProfile.jsx
@@ -23,6 +23,7 @@ import DietSubBoard from './DietSubBoard';
 import CrewingSubBoard from './CrewingSubBoard';
 import Nav from '../Components/Nav';
 import FollowButton from '../Components/FollowButton';
+import useNotFoundPage from '../utils/hooks/useNotFoundPage';
 
 function UserProfile() {
   const navigate = useNavigate();
@@ -41,13 +42,18 @@ function UserProfile() {
     new Array(3).fill({})
   ); // Mockup data
 
+  const { notFound, NotFoundPage, handleNotFoundErrors } = useNotFoundPage();
+
   const fetchUser = () => {
     axios
       .get(`${import.meta.env.VITE_API_URL}/members/${profileMemberId}`)
       .then((res) => {
         setUser(res.data);
       })
-      .catch((error) => console.log(error));
+      .catch((error) => {
+        console.log(error);
+        handleNotFoundErrors(error);
+      });
   };
 
   const fetchFollowInfo = () => {
@@ -98,6 +104,10 @@ function UserProfile() {
     updateFollowerList();
     fetchFollowingList();
   }, [profileMemberId]);
+
+  if (notFound) {
+    return <NotFoundPage />;
+  }
 
   return (
     <ProfilePageBody>

--- a/client/src/utils/hooks/useNotFoundPage.js
+++ b/client/src/utils/hooks/useNotFoundPage.js
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+import NotFoundPage from '../../Components/NotFoundPage';
+
+function useNotFoundPage() {
+  const [notFound, setNotFound] = useState(false);
+
+  const handleNotFoundErrors = (error) => {
+    if (error.response && error.response.status === 404) {
+      setNotFound(true);
+    } else {
+      console.error(error);
+    }
+  };
+
+  return { notFound, NotFoundPage, handleNotFoundErrors };
+}
+
+export default useNotFoundPage;


### PR DESCRIPTION
Detail 페이지, UserProfile 페이지 등에서 게시글이나 유저 정보 등을 불러올 때 존재하지 않는 리소스에 대한 요청의 응답으로 404 not found 에러가 반환될 경우, NotFoundPage를 보여주고 이전 페이지로 이동시키는 로직을 구현한다.
또한 존재하지 않는 루트로 접근할 경우(예 : myservice.com/asdfsdf로 접근) NotFoundPage가 출력되도록 처리한다.

- [x] NotFoundPage 구현
- [x] 여러 페이지에 적용하기 쉽도록 useNotFoundPage 훅 구현
- [x] UserProfile, PostDetail, CrewingDetail에 NotFoundPage 적용
- [x] 상세보기 페이지에서만 NotFoundPage가 표시되도록 PostDetailBox를 분리하여 별개의 컴포넌트인 PostDetailPageBox 구현
- [x] 잘못된 페이지 접근 시 NotFoundPage 보여주도록 App.jsx의 Route 설정 추가
