### PR TITLE
[FE] 팔로우 리스트 기능 구현

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <div id="modal-root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/client/src/Components/FollowList.jsx
+++ b/client/src/Components/FollowList.jsx
@@ -1,0 +1,54 @@
+import ProfileLink from '../utils/ProfileLink';
+import {
+  EmptyListHeading,
+  EmptyListIndicator,
+  EmptyListSubHeading,
+  ListItemContainer,
+  ListItemProfileImage,
+  ListItemUsername,
+  ModalContainer,
+  ModalList,
+} from './FollowList.style';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faFaceSadTear } from '@fortawesome/free-regular-svg-icons';
+
+function FollowList({ list }) {
+  const isEmptyList = list && list.length === 0;
+
+  return (
+    <ModalContainer>
+      {isEmptyList ? (
+        <EmptyListIndicator>
+          <FontAwesomeIcon icon={faFaceSadTear} size="2x" />
+          <EmptyListHeading>텅~</EmptyListHeading>
+          <EmptyListSubHeading>비었어요...</EmptyListSubHeading>
+        </EmptyListIndicator>
+      ) : (
+        <ModalList>
+          {list.map((item) => (
+            <ListItemContainer key={item.memberId}>
+              <ProfileLink
+                profileUserId={item.memberId}
+                element={
+                  <ListItemProfileImage>
+                    <img
+                      style={{ width: '100%' }}
+                      src={item.imageUrl}
+                      alt={item.memberId}
+                    />
+                  </ListItemProfileImage>
+                }
+              />
+              <ProfileLink
+                profileUserId={item.memberId}
+                element={<ListItemUsername>{item.userName}</ListItemUsername>}
+              />
+            </ListItemContainer>
+          ))}
+        </ModalList>
+      )}
+    </ModalContainer>
+  );
+}
+
+export default FollowList;

--- a/client/src/Components/FollowList.style.js
+++ b/client/src/Components/FollowList.style.js
@@ -1,0 +1,65 @@
+import styled from 'styled-components';
+
+export const ModalContainer = styled.section`
+  width: 13rem;
+  max-height: 10rem;
+  overflow-y: auto;
+  background-color: white;
+  padding: 0.5rem 0;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  z-index: 10;
+`;
+export const EmptyListIndicator = styled.section`
+  color: #b0b0b0;
+  height: 9rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const EmptyListHeading = styled.section`
+  margin: 0.2rem;
+  font-size: 2rem;
+`;
+export const EmptyListSubHeading = styled.section`
+  font-size: 1rem;
+`;
+
+export const ModalList = styled.ul`
+  width: 100%;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const ListItemContainer = styled.li`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  padding: 5px 10px;
+  /* border-bottom: 1px dotted #ededed;
+  &:last-child {
+    border-bottom: none;
+  } */
+  &:hover {
+    background-color: #f8f8f8;
+    cursor: pointer;
+  }
+`;
+
+export const ListItemProfileImage = styled.section`
+  border-radius: 70%;
+  width: 2rem;
+  height: 2rem;
+  overflow: hidden;
+  object-fit: cover;
+  margin-right: 1rem;
+`;
+
+export const ListItemUsername = styled.section`
+  font-weight: bold;
+`;

--- a/client/src/Components/MyProfile.jsx
+++ b/client/src/Components/MyProfile.jsx
@@ -11,6 +11,10 @@ import {
   UsernameContainer,
 } from './MyProfile.style';
 
+import PortalModal from '../utils/PortalModal';
+import FollowList from './FollowList';
+import usePortalModal from '../utils/hooks/usePortalModal';
+
 function MyProfile() {
   const memberId = sessionStorage.getItem('memberId') || 3;
   const [user, setUser] = useState({
@@ -25,6 +29,10 @@ function MyProfile() {
   const [userFollowingList, setUserFollowingList] = useState(
     new Array(3).fill({})
   ); // Mockup data
+
+  const followerModal = usePortalModal();
+  const followingModal = usePortalModal();
+
   useEffect(() => {
     axios
       .get(`${import.meta.env.VITE_API_URL}/members/${memberId}`)
@@ -73,6 +81,22 @@ function MyProfile() {
 
   return (
     <MyProfileContainer>
+      {followerModal.showModal && (
+        <PortalModal
+          position={followerModal.modalPosition}
+          onOutsideClick={followerModal.closeModal}
+        >
+          <FollowList list={userFollowerList} />
+        </PortalModal>
+      )}
+      {followingModal.showModal && (
+        <PortalModal
+          position={followingModal.modalPosition}
+          onOutsideClick={followingModal.closeModal}
+        >
+          <FollowList list={userFollowingList} />
+        </PortalModal>
+      )}
       <ProfileImageContainer>
         <img
           style={{ width: '100%' }}
@@ -86,11 +110,11 @@ function MyProfile() {
           <UserStatsTitle>게시글</UserStatsTitle>
           <UserStatsNumber>{user.totalPostCount}</UserStatsNumber>
         </UserStatsItem>
-        <UserStatsItem>
+        <UserStatsItem onClick={followerModal.openModal}>
           <UserStatsTitle>팔로워</UserStatsTitle>
           <UserStatsNumber>{userFollowerList.length}</UserStatsNumber>
         </UserStatsItem>
-        <UserStatsItem>
+        <UserStatsItem onClick={followingModal.openModal}>
           <UserStatsTitle>팔로잉</UserStatsTitle>
           <UserStatsNumber>{userFollowingList.length}</UserStatsNumber>
         </UserStatsItem>

--- a/client/src/Components/MyProfile.style.js
+++ b/client/src/Components/MyProfile.style.js
@@ -43,6 +43,7 @@ export const UserStatsItem = styled.section`
   align-items: center;
   width: 72px;
   margin: 8px;
+  cursor: default;
 `;
 
 export const UserStatsTitle = styled.section`

--- a/client/src/Pages/MyPage.jsx
+++ b/client/src/Pages/MyPage.jsx
@@ -24,6 +24,10 @@ import DietSubBoard from './DietSubBoard';
 import CrewingSubBoard from './CrewingSubBoard';
 import Nav from '../Components/Nav';
 
+import PortalModal from '../utils/PortalModal';
+import FollowList from '../Components/FollowList';
+import usePortalModal from '../utils/hooks/usePortalModal';
+
 function MyPage() {
   const memberId = sessionStorage.getItem('memberId');
   const [user, setUser] = useState({
@@ -38,6 +42,9 @@ function MyPage() {
   const [userFollowingList, setUserFollowingList] = useState(
     new Array(3).fill({})
   ); // Mockup data
+
+  const followerModal = usePortalModal();
+  const followingModal = usePortalModal();
 
   useEffect(() => {
     axios
@@ -87,6 +94,22 @@ function MyPage() {
 
   return (
     <ProfilePageBody>
+      {followerModal.showModal && (
+        <PortalModal
+          position={followerModal.modalPosition}
+          onOutsideClick={followerModal.closeModal}
+        >
+          <FollowList list={userFollowerList} />
+        </PortalModal>
+      )}
+      {followingModal.showModal && (
+        <PortalModal
+          position={followingModal.modalPosition}
+          onOutsideClick={followingModal.closeModal}
+        >
+          <FollowList list={userFollowingList} />
+        </PortalModal>
+      )}
       <Nav />
       <MainContainer>
         <ProfilePageMain>
@@ -110,11 +133,11 @@ function MyPage() {
                   <UserStatTitle>게시글</UserStatTitle>
                   <UserStatNumber>{user.totalPostCount}</UserStatNumber>
                 </UserStatsItem>
-                <UserStatsItem>
+                <UserStatsItem onClick={followerModal.openModal}>
                   <UserStatTitle>팔로워</UserStatTitle>
                   <UserStatNumber>{userFollowerList.length}</UserStatNumber>
                 </UserStatsItem>
-                <UserStatsItem>
+                <UserStatsItem onClick={followingModal.openModal}>
                   <UserStatTitle>팔로잉</UserStatTitle>
                   <UserStatNumber>{userFollowingList.length}</UserStatNumber>
                 </UserStatsItem>

--- a/client/src/Pages/ProfilePage.style.js
+++ b/client/src/Pages/ProfilePage.style.js
@@ -67,6 +67,7 @@ export const UserStatsContainer = styled.section`
 export const UserStatsItem = styled.section`
   display: flex;
   margin-right: 30px;
+  cursor: default;
 `;
 
 export const UserStatTitle = styled.section`

--- a/client/src/Pages/UserProfile.jsx
+++ b/client/src/Pages/UserProfile.jsx
@@ -25,6 +25,10 @@ import Nav from '../Components/Nav';
 import FollowButton from '../Components/FollowButton';
 import useNotFoundPage from '../utils/hooks/useNotFoundPage';
 
+import PortalModal from '../utils/PortalModal';
+import FollowList from '../Components/FollowList';
+import usePortalModal from '../utils/hooks/usePortalModal';
+
 function UserProfile() {
   const navigate = useNavigate();
   const loggedInUserId = sessionStorage.getItem('memberId');
@@ -41,6 +45,9 @@ function UserProfile() {
   const [userFollowingList, setUserFollowingList] = useState(
     new Array(3).fill({})
   ); // Mockup data
+
+  const followerModal = usePortalModal();
+  const followingModal = usePortalModal();
 
   const { notFound, NotFoundPage, handleNotFoundErrors } = useNotFoundPage();
 
@@ -78,6 +85,7 @@ function UserProfile() {
       })
       .then((res) => {
         setUserFollowerList(res.data);
+        console.log(userFollowerList);
       })
       .catch((error) => console.log(error));
   };
@@ -111,6 +119,22 @@ function UserProfile() {
 
   return (
     <ProfilePageBody>
+      {followerModal.showModal && (
+        <PortalModal
+          position={followerModal.modalPosition}
+          onOutsideClick={followerModal.closeModal}
+        >
+          <FollowList list={userFollowerList} />
+        </PortalModal>
+      )}
+      {followingModal.showModal && (
+        <PortalModal
+          position={followingModal.modalPosition}
+          onOutsideClick={followingModal.closeModal}
+        >
+          <FollowList list={userFollowingList} />
+        </PortalModal>
+      )}
       <Nav />
       <MainContainer>
         <ProfilePageMain>
@@ -135,11 +159,11 @@ function UserProfile() {
                   <UserStatTitle>게시글</UserStatTitle>
                   <UserStatNumber>{user.totalPostCount}</UserStatNumber>
                 </UserStatsItem>
-                <UserStatsItem>
+                <UserStatsItem onClick={followerModal.openModal}>
                   <UserStatTitle>팔로워</UserStatTitle>
                   <UserStatNumber>{userFollowerList.length}</UserStatNumber>
                 </UserStatsItem>
-                <UserStatsItem>
+                <UserStatsItem onClick={followingModal.openModal}>
                   <UserStatTitle>팔로잉</UserStatTitle>
                   <UserStatNumber>{userFollowingList.length}</UserStatNumber>
                 </UserStatsItem>

--- a/client/src/utils/PortalModal.jsx
+++ b/client/src/utils/PortalModal.jsx
@@ -1,0 +1,38 @@
+import { useEffect, useRef } from 'react';
+import ReactDOM from 'react-dom';
+
+function PortalModal({ children, position, onOutsideClick }) {
+  const elRef = useRef(null);
+  if (!elRef.current) {
+    elRef.current = document.createElement('div');
+  }
+
+  useEffect(() => {
+    const modalRoot = document.getElementById('modal-root');
+    const modalElement = elRef.current;
+
+    if (modalRoot) {
+      modalRoot.appendChild(modalElement);
+      modalElement.style.position = 'absolute';
+      modalElement.style.top = `${position.y + 5}px`;
+      modalElement.style.left = `${position.x}px`;
+
+      const handleOutsideClick = (event) => {
+        if (!modalElement.contains(event.target)) {
+          onOutsideClick && onOutsideClick();
+        }
+      };
+
+      window.addEventListener('mousedown', handleOutsideClick);
+
+      return () => {
+        modalRoot.removeChild(modalElement);
+        window.removeEventListener('mousedown', handleOutsideClick);
+      };
+    }
+  }, [position, onOutsideClick]);
+
+  return ReactDOM.createPortal(children, elRef.current);
+}
+
+export default PortalModal;

--- a/client/src/utils/hooks/usePortalModal.js
+++ b/client/src/utils/hooks/usePortalModal.js
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+
+function usePortalModal() {
+  const [showModal, setShowModal] = useState(false);
+  const [modalPosition, setModalPosition] = useState({ x: 0, y: 0 });
+
+  const openModal = (event) => {
+    console.log('Open modal is called');
+    const rect = event.target.getBoundingClientRect();
+    setModalPosition({ x: rect.left, y: rect.bottom });
+    setShowModal(true);
+  };
+
+  const closeModal = () => {
+    setShowModal(false);
+  };
+
+  return {
+    showModal,
+    modalPosition,
+    openModal,
+    closeModal,
+  };
+}
+
+export default usePortalModal;


### PR DESCRIPTION
사용자의 팔로워/팔로잉 리스트를 보여주는 기능을 구현한다.

- [x] 팔로워/팔로잉 리스트는 MyProfile/MyPage/UserProfile에 적용한다
- [x] 각 페이지에서 '팔로워' '팔로잉' 영역을 클릭하면 리스트가 모달 형식으로 표시된다.
- [x] 모달 창 이외의 부분을 클릭하면 모달창이 종료된다.
- [x] 모달 창 내에서 리스트 길이에 따라 스크롤을 제공한다.
- [x] 리스트가 비어있을 경우 메세지를 표시한다.
- [x] 모달창은 클릭된 UserStatsItem을 기준으로 아래에 표시된다.
- [x] 리스트에 사용자의 프로필사진과 닉네임을 표시한다.
- [x] 사용자를 클릭하면 해당 사용자의 프로필로 이동할 수 있다.