### PR TITLE
[FE] 크루잉 상세보기 페이지 수정

### DIFF
--- a/client/src/Components/CrewingContent.jsx
+++ b/client/src/Components/CrewingContent.jsx
@@ -16,6 +16,7 @@ function CrewingContent({ data, type }) {
   const url = `${import.meta.env.VITE_API_URL}/crewing/apply/${data.crewingId}`;
   const [isLoding, setIsLoding] = useState(true);
   const [update] = useUpdatePost(data.crewingId, type, setIsLoding);
+  const isUnlimited = data.maxPeople === 999;
 
   const participation = () => {
     axios
@@ -62,7 +63,7 @@ function CrewingContent({ data, type }) {
         <CrewingInfo.PersonnelStatus>
           <Label>모집인원</Label>
           <Content>{`${data.currentPeople} / ${
-            data.maxPeople === 999 ? '무제한' : data.maxPeople
+            isUnlimited ? '무제한' : data.maxPeople
           }`}</Content>
         </CrewingInfo.PersonnelStatus>
       </CrewingInfo.Container>

--- a/client/src/Components/CrewingContent.jsx
+++ b/client/src/Components/CrewingContent.jsx
@@ -8,6 +8,7 @@ import {
 } from './CrewingContent.style';
 import useUpdatePost from '../utils/hooks/useUpdatePost';
 import axios from 'axios';
+import koTime from '../utils/koTime';
 
 function CrewingContent({ data, type }) {
   const loginId = sessionStorage.getItem('memberId');
@@ -52,15 +53,17 @@ function CrewingContent({ data, type }) {
       <CrewingInfo.Container>
         <CrewingInfo.ActivityDate>
           <Label>활동 날짜</Label>
-          <Content>{data.activityDate}</Content>
+          <Content>{koTime(data.activityDate)}</Content>
         </CrewingInfo.ActivityDate>
         <CrewingInfo.DeadLine>
           <Label>모집마감일</Label>
-          <Content>{data.deadLine}</Content>
+          <Content>{koTime(data.deadLine)}</Content>
         </CrewingInfo.DeadLine>
         <CrewingInfo.PersonnelStatus>
           <Label>모집인원</Label>
-          <Content>{`${data.currentPeople} / ${data.maxPeople}`}</Content>
+          <Content>{`${data.currentPeople} / ${
+            data.maxPeople === 999 ? '무제한' : data.maxPeople
+          }`}</Content>
         </CrewingInfo.PersonnelStatus>
       </CrewingInfo.Container>
       <CrewingParticipationBtn

--- a/client/src/Components/PostDetailModal.jsx
+++ b/client/src/Components/PostDetailModal.jsx
@@ -7,6 +7,8 @@ function PostDetailModal({ postId, type, setIsModal }) {
   const closeIcon = faXmark;
   const [isNotFound, setIsNotFound] = useState(false);
 
+  console.log(postId);
+
   // 모달 닫기
   const closeModal = () => {
     setIsModal(false);

--- a/client/src/Components/PostDetailPageBox.jsx
+++ b/client/src/Components/PostDetailPageBox.jsx
@@ -41,7 +41,7 @@ function PostDetailPageBox({ postId, type }) {
         },
       })
       .then((response) => {
-        dispatch(postDataSlice.actions.update(response.data.data));
+        dispatch(postDataSlice.actions.update(response.data));
         setIsLoading(false);
       })
       .catch((error) => {
@@ -55,6 +55,8 @@ function PostDetailPageBox({ postId, type }) {
   }, []);
 
   const data = useSelector((state) => state.postData.data);
+
+  console.log(data);
 
   if (notFound) {
     return <NotFoundPage />;

--- a/client/src/utils/hooks/useUpdatePost.js
+++ b/client/src/utils/hooks/useUpdatePost.js
@@ -28,7 +28,12 @@ function useUpdatePost(postId, type, setIsLodig) {
         },
       })
       .then((response) => {
-        dispatch(postDataSlice.actions.update(response.data.data));
+        if (type === 'crewing') {
+          dispatch(postDataSlice.actions.update(response.data));
+        } else {
+          dispatch(postDataSlice.actions.update(response.data.data));
+        }
+
         setIsLodig(false);
         setResCode(response.status);
       })

--- a/client/src/utils/koTime.js
+++ b/client/src/utils/koTime.js
@@ -1,0 +1,23 @@
+function koTime(utcTime) {
+  const date = new Date(utcTime);
+  const koreanTime = new Date(date.getTime() + 9 * 60 * 60 * 1000);
+
+  // 한국 시간 형식으로 변환
+  const year = koreanTime.getFullYear();
+  const month = String(koreanTime.getMonth() + 1).padStart(2, '0');
+  const day = String(koreanTime.getDate()).padStart(2, '0');
+  let hours = koreanTime.getHours();
+  const minutes = String(koreanTime.getMinutes()).padStart(2, '0');
+  let meridiem = '오전';
+
+  if (hours >= 12) {
+    meridiem = '오후';
+    hours %= 12;
+  }
+
+  hours = String(hours).padStart(2, '0');
+
+  return `${year}-${month}-${day} ${meridiem} ${hours}:${minutes}`;
+}
+
+export default koTime;


### PR DESCRIPTION
- 크루잉 요청과 운동/식단 게시물 신청 시 response data에 담긴 형태가 달라 크루잉 상세보기 화면이 표시되지않는 문제를 별도의 분기 처리를 통해 해결했습니다.

- 크루잉 게시물 상세보기의 날짜형식을 변환하여 보여주는 함수를 작성 후 적용하였습니다.

- 인원 무제한시 (모집인원 수가 999 표시 될 경우) 모집인원이 '무제한' 으로 표시되도록 수정하였습니다.