### PR TITLE
[FE] 리프레시 토큰 사용로직 수정, PrivateRoute 기능 확장, 로그인 로직 변경

### DIFF
--- a/client/src/Components/CommentContent.jsx
+++ b/client/src/Components/CommentContent.jsx
@@ -5,7 +5,7 @@ import { useSelector } from 'react-redux';
 import ProfileLink from '../utils/ProfileLink';
 
 function CommentContent({ CommentData, setIsEdit, type }) {
-  const loginId = sessionStorage.getItem('memberId') + '';
+  const loginId = localStorage.getItem('memberId') + '';
   const memberId = CommentData.memberId + '';
 
   return (

--- a/client/src/Components/CommentEdit.jsx
+++ b/client/src/Components/CommentEdit.jsx
@@ -2,9 +2,11 @@ import React, { useState } from 'react';
 import { Edit, Btn } from './CommentEdit.style';
 import axios from 'axios';
 import useUpdatePost from '../utils/hooks/useUpdatePost';
+import { useApi } from '../utils/hooks/useApi';
 
 function CommentEdit({ CommentData, setIsEdit, type }) {
-  const accessToken = sessionStorage.getItem('authToken');
+  const api = useApi();
+  const accessToken = localStorage.getItem('authToken');
   const url = `${import.meta.env.VITE_API_URL}/comments/${
     CommentData.commentId
   }`;
@@ -14,7 +16,7 @@ function CommentEdit({ CommentData, setIsEdit, type }) {
 
   // 댓글 수정 API
   const EditData = () => {
-    axios
+    api
       .put(
         url,
         {

--- a/client/src/Components/CommentEditDelete.jsx
+++ b/client/src/Components/CommentEditDelete.jsx
@@ -2,18 +2,20 @@ import React, { useState } from 'react';
 import { Btn } from './CommentEditDelete.style';
 import axios from 'axios';
 import useUpdatePost from '../utils/hooks/useUpdatePost';
+import { useApi } from '../utils/hooks/useApi';
 
 function CommentEditDelete({ CommentData, commentId, setIsEdit, type }) {
-  const loginId = sessionStorage.getItem('memberId') + '';
+  const api = useApi();
+  const loginId = localStorage.getItem('memberId') + '';
   const memberId = CommentData.memberId + '';
-  const accessToken = sessionStorage.getItem('authToken');
+  const accessToken = localStorage.getItem('authToken');
   const url = `${import.meta.env.VITE_API_URL}/comments/${commentId}`;
   const [isLoding, setIsLoding] = useState(true);
   const [update] = useUpdatePost(CommentData.postId, type, setIsLoding);
 
   // 게시글 댓글 삭제 API
   const DeleteData = () => {
-    axios
+    api
       .delete(url, {
         headers: {
           Authorization: accessToken,

--- a/client/src/Components/CreateCrewing.jsx
+++ b/client/src/Components/CreateCrewing.jsx
@@ -16,6 +16,7 @@ import ImageCropper from './ImageCropper.jsx';
 import { faXmark } from '@fortawesome/free-solid-svg-icons';
 import { format } from 'date-fns';
 import CreateCrewingStyle from './CreateCrewing.style.js';
+import { useApi } from '../utils/hooks/useApi.js';
 
 const StyledDatePicker = styled(DatePicker)`
   width: 328px !important;
@@ -26,6 +27,7 @@ const StyledDatePicker = styled(DatePicker)`
 
 export default function CreateCrewing() {
   const navigate = useNavigate();
+  const api = useApi();
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const [activity, setActivity] = useState(null);
@@ -73,8 +75,8 @@ export default function CreateCrewing() {
   };
 
   const handleFormSubmit = () => {
-    const authToken = sessionStorage.getItem('authToken');
-    const memberId = sessionStorage.getItem('memberId');
+    const authToken = localStorage.getItem('authToken');
+    const memberId = localStorage.getItem('memberId');
     const formattedDeadline = format(deadline, "yyyy-MM-dd'T'HH:mm:ss");
     const postData = {
       title: title,
@@ -89,13 +91,13 @@ export default function CreateCrewing() {
     };
     console.log(postData);
 
-    axios
+    api
       .post(`${import.meta.env.VITE_API_URL}/crewings`, postData, {
         headers: { Authorization: authToken },
       })
       .then((response) => {
         console.log('게시물 작성 완료:', response.data);
-        navigate('/');
+        navigate('/crewing');
       })
       .catch((error) => {
         console.error('게시물 작성 실패:', error);
@@ -222,7 +224,14 @@ export default function CreateCrewing() {
             </CreateCrewingStyle.Input>
           </CreateCrewingStyle.Main>
           <button
-            disabled={!title || !content || !activity || !deadline}
+            disabled={
+              !uploadedImageUrl ||
+              !title ||
+              !content ||
+              !activity ||
+              !deadline ||
+              (isRecruitChecked && !number)
+            }
             onClick={handleFormSubmit}
           >
             작성 완료

--- a/client/src/Components/CreateDiet.jsx
+++ b/client/src/Components/CreateDiet.jsx
@@ -9,8 +9,10 @@ import { useNavigate } from 'react-router-dom';
 import useImageCropAndUpload from '../utils/hooks/useImageCropAndUpload.js';
 import ImageCropper from './ImageCropper.jsx';
 import { faCheck, faXmark } from '@fortawesome/free-solid-svg-icons';
+import { useApi } from '../utils/hooks/useApi.js';
 
 export default function CreateDiet() {
+  const api = useApi();
   const navigate = useNavigate();
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
@@ -41,8 +43,8 @@ export default function CreateDiet() {
   };
 
   const handleFormSubmit = () => {
-    const authToken = sessionStorage.getItem('authToken');
-    const memberId = sessionStorage.getItem('memberId');
+    const authToken = localStorage.getItem('authToken');
+    const memberId = localStorage.getItem('memberId');
     const postData = {
       title: title,
       content: content,
@@ -52,13 +54,13 @@ export default function CreateDiet() {
       memberId: memberId,
     };
 
-    axios
+    api
       .post(`${import.meta.env.VITE_API_URL}/posts`, postData, {
         headers: { Authorization: authToken },
       })
       .then((response) => {
         console.log('게시물 작성 완료:', response.data);
-        navigate('/');
+        navigate('/diet');
       })
       .catch((error) => {
         console.error('게시물 작성 실패:', error);

--- a/client/src/Components/CreateWorkout.jsx
+++ b/client/src/Components/CreateWorkout.jsx
@@ -8,9 +8,11 @@ import { useNavigate } from 'react-router-dom';
 import useImageCropAndUpload from '../utils/hooks/useImageCropAndUpload.js';
 import ImageCropper from './ImageCropper.jsx';
 import { faCheck, faXmark } from '@fortawesome/free-solid-svg-icons';
+import { useApi } from '../utils/hooks/useApi.js';
 
 export default function CreateWorkout() {
   const navigate = useNavigate();
+  const api = useApi();
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const [showCropper, setShowCropper] = useState(false); // 크로퍼 표시 상태
@@ -39,8 +41,8 @@ export default function CreateWorkout() {
   };
 
   const handleFormSubmit = () => {
-    const authToken = sessionStorage.getItem('authToken');
-    const memberId = sessionStorage.getItem('memberId');
+    const authToken = localStorage.getItem('authToken');
+    const memberId = localStorage.getItem('memberId');
 
     const postData = {
       title: title,
@@ -50,13 +52,13 @@ export default function CreateWorkout() {
       memberId: memberId,
     };
 
-    axios
+    api
       .post(`${import.meta.env.VITE_API_URL}/posts`, postData, {
         headers: { Authorization: authToken },
       })
       .then((response) => {
         console.log('게시물 작성 완료:', response.data);
-        navigate('/');
+        navigate('/workout');
       })
       .catch((error) => {
         console.error('게시물 작성 실패:', error);

--- a/client/src/Components/CrewingContent.jsx
+++ b/client/src/Components/CrewingContent.jsx
@@ -9,8 +9,10 @@ import {
 import useUpdatePost from '../utils/hooks/useUpdatePost';
 import axios from 'axios';
 import koTime from '../utils/koTime';
+import { useApi } from '../utils/hooks/useApi';
 
 function CrewingContent({ data, type }) {
+  const api = useApi();
   const loginId = sessionStorage.getItem('memberId');
   const accessToken = sessionStorage.getItem('authToken');
   const url = `${import.meta.env.VITE_API_URL}/crewing/apply/${data.crewingId}`;
@@ -19,7 +21,7 @@ function CrewingContent({ data, type }) {
   const isUnlimited = data.maxPeople === 999;
 
   const participation = () => {
-    axios
+    api
       .post(
         url,
         {

--- a/client/src/Components/DeleteModal.jsx
+++ b/client/src/Components/DeleteModal.jsx
@@ -13,8 +13,10 @@ import {
 import { faXmark } from '@fortawesome/free-solid-svg-icons';
 import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
+import { useApi } from '../utils/hooks/useApi';
 
 function DeleteModal({ isModalOpen, handleModalToggle, memberId }) {
+  const api = useApi();
   const navigate = useNavigate();
 
   const [password, setPassword] = useState('');
@@ -47,9 +49,9 @@ function DeleteModal({ isModalOpen, handleModalToggle, memberId }) {
   }, [password, confirmationText]);
 
   const handleDeleteButtonClick = () => {
-    const authToken = sessionStorage.getItem('authToken');
+    const authToken = localStorage.getItem('authToken');
 
-    axios
+    api
       .put(
         `${import.meta.env.VITE_API_URL}/members/delete/${memberId}`,
         { password: password },
@@ -62,7 +64,7 @@ function DeleteModal({ isModalOpen, handleModalToggle, memberId }) {
       .then((response) => {
         if (response.status === 200) {
           alert('성공적으로 탈퇴되었습니다.');
-          sessionStorage.clear();
+          localStorage.clear();
           navigate('/login');
         }
       })
@@ -70,7 +72,7 @@ function DeleteModal({ isModalOpen, handleModalToggle, memberId }) {
         if (error.response) {
           if (error.response.status === 401) {
             alert('권한이 유효하지 않습니다. 다시 로그인해주세요.');
-            sessionStorage.clear();
+            localStorage.clear();
             navigate('/login');
           } else if (error.response.status === 400) {
             alert('비밀번호가 일치하지 않습니다. 다시 시도해주세요.');

--- a/client/src/Components/FollowButton.jsx
+++ b/client/src/Components/FollowButton.jsx
@@ -1,10 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import { ActiveButton, InactiveButton } from './FollowButton.style';
+import { useApi } from '../utils/hooks/useApi';
 
 function FollowButton({ profileUserId, updateFollowerList }) {
+  const api = useApi();
   const [isFollowing, setIsFollowing] = useState(false);
-  const loggedInUserId = Number(sessionStorage.getItem('memberId'));
+  const loggedInUserId = Number(localStorage.getItem('memberId'));
+  const authToken = localStorage.getItem('authToken');
 
   useEffect(() => {
     checkFollowing();
@@ -30,11 +33,15 @@ function FollowButton({ profileUserId, updateFollowerList }) {
   };
 
   const handleClick = () => {
-    axios
-      .post(`${import.meta.env.VITE_API_URL}/follows`, {
-        followerId: loggedInUserId,
-        followingId: profileUserId,
-      })
+    api
+      .post(
+        `${import.meta.env.VITE_API_URL}/follows`,
+        {
+          followerId: loggedInUserId,
+          followingId: profileUserId,
+        },
+        { headers: { Authorization: authToken } }
+      )
       .then((response) => {
         if (response.status === 200) {
           setIsFollowing(!isFollowing);

--- a/client/src/Components/LoginForm.jsx
+++ b/client/src/Components/LoginForm.jsx
@@ -63,11 +63,11 @@ function LoginForm() {
         if (res.status === 200) {
           const authToken = res.headers['authorization'];
           const refreshToken = res.headers['refresh'];
-          sessionStorage.setItem('authToken', authToken);
-          sessionStorage.setItem('refreshToken', refreshToken);
+          localStorage.setItem('authToken', authToken);
+          localStorage.setItem('refreshToken', refreshToken);
           const decoded = jwtDecode(authToken);
           console.log(typeof decoded.memberId);
-          sessionStorage.setItem('memberId', decoded.memberId);
+          localStorage.setItem('memberId', decoded.memberId);
           navigate('/');
         } else {
           setForm({ email: '', password: '' }); // Reset form input values

--- a/client/src/Components/MainBoard.jsx
+++ b/client/src/Components/MainBoard.jsx
@@ -10,7 +10,7 @@ function MainBoard() {
     TITLE_MAIN: '오늘은 무슨 활동을 하셨나요?',
     BTN_MAIN: '만들기',
   };
-  const loginId = sessionStorage.getItem('memberId');
+  const loginId = localStorage.getItem('memberId');
   // get 요청 url
   const url = `${import.meta.env.VITE_API_URL}/posts/followingPosts`;
 

--- a/client/src/Components/MyProfile.jsx
+++ b/client/src/Components/MyProfile.jsx
@@ -16,10 +16,10 @@ import FollowList from './FollowList';
 import usePortalModal from '../utils/hooks/usePortalModal';
 
 function MyProfile() {
-  const memberId = sessionStorage.getItem('memberId') || 3;
+  const memberId = localStorage.getItem('memberId') || 3;
   const [user, setUser] = useState({
     imageUrl: '/images/defaultprofile.png',
-    userName: 'Username',
+    userName: '_',
     totalPostCount: 0,
   });
   const [userFollowInfo, setUserFollowInfo] = useState({});

--- a/client/src/Components/MyProfile.style.js
+++ b/client/src/Components/MyProfile.style.js
@@ -27,6 +27,7 @@ export const UsernameContainer = styled.section`
   font-size: 18px;
   font-weight: bold;
   margin-bottom: 50px;
+  min-height: 21px;
 `;
 
 export const UserStatsContainer = styled.section`
@@ -43,6 +44,7 @@ export const UserStatsItem = styled.section`
   align-items: center;
   width: 72px;
   margin: 8px;
+  min-height: 47px;
   cursor: default;
 `;
 

--- a/client/src/Components/PasswordModal.jsx
+++ b/client/src/Components/PasswordModal.jsx
@@ -11,10 +11,11 @@ import {
 import { faXmark } from '@fortawesome/free-solid-svg-icons';
 import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
+import { useApi } from '../utils/hooks/useApi';
 
 function PasswordModal({ isModalOpen, handleModalToggle, memberId }) {
   const navigate = useNavigate();
-
+  const api = useApi();
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
@@ -68,9 +69,9 @@ function PasswordModal({ isModalOpen, handleModalToggle, memberId }) {
   }, [newPassword, confirmPassword]);
 
   const handlePasswordChangeButtonClick = () => {
-    const authToken = sessionStorage.getItem('authToken');
+    const authToken = localStorage.getItem('authToken');
 
-    axios
+    api
       .put(
         `${import.meta.env.VITE_API_URL}/members/putPassword/${memberId}`,
         { currentPassword: currentPassword, newPassword: newPassword },
@@ -90,7 +91,7 @@ function PasswordModal({ isModalOpen, handleModalToggle, memberId }) {
         if (error.response) {
           if (error.response.status === 401) {
             alert('권한이 유효하지 않습니다. 다시 로그인해주세요.');
-            sessionStorage.clear();
+            localStorage.clear();
             navigate('/login');
           } else if (error.response.status === 400) {
             alert('비밀번호가 일치하지 않습니다. 다시 시도해주세요.');

--- a/client/src/Components/PostCommentInput.jsx
+++ b/client/src/Components/PostCommentInput.jsx
@@ -2,9 +2,11 @@ import React, { useRef, useState, useEffect } from 'react';
 import { InputContainer } from './PostCommentInput.style';
 import axios from 'axios';
 import useUpdatePost from '../utils/hooks/useUpdatePost';
+import { useApi } from '../utils/hooks/useApi';
 
 function PostCommentInput({ data, type, scrollToTop }) {
-  const accessToken = sessionStorage.getItem('authToken');
+  const api = useApi();
+  const accessToken = localStorage.getItem('authToken');
   const url = `${import.meta.env.VITE_API_URL}/comments`;
   const [commentText, setCommentText] = useState('');
   const [isLoding, setIsLodig] = useState(true);
@@ -14,7 +16,7 @@ function PostCommentInput({ data, type, scrollToTop }) {
   });
 
   // 로그인된 사용자의 멤버아이디
-  const loginId = sessionStorage.getItem('memberId');
+  const loginId = localStorage.getItem('memberId');
 
   useEffect(() => {
     axios
@@ -28,7 +30,7 @@ function PostCommentInput({ data, type, scrollToTop }) {
   //댓글작성 api
   const postData = () => {
     if (commentText !== '') {
-      axios
+      api
         .post(
           url,
           {

--- a/client/src/Components/PostContent.jsx
+++ b/client/src/Components/PostContent.jsx
@@ -13,23 +13,25 @@ import axios from 'axios';
 import CrewingContent from './CrewingContent';
 import formatTime from '../utils/formatTime';
 import ProfileLink from '../utils/ProfileLink';
+import { useApi } from '../utils/hooks/useApi';
 
 function PostContent({ data, type, isEdit, setIsEdit }) {
+  const api = useApi();
   const [title, setTitle] = useState(data.title);
   const [content, setContent] = useState(data.content);
-  const accessToken = sessionStorage.getItem('authToken');
+  const accessToken = localStorage.getItem('authToken');
   const EditPostUrl = `${import.meta.env.VITE_API_URL}/posts/${data.postId}`;
   const EditCrewingUrl = `${import.meta.env.VITE_API_URL}/crewing/${
     data.crewingId
   }`;
   const [isLoding, setIsLoding] = useState(true);
   const [update] = useUpdatePost(data.postId, type, setIsLoding);
-  const loginId = sessionStorage.getItem('memberId') + '';
+  const loginId = localStorage.getItem('memberId') + '';
   const memberId = data.memberId + '';
 
   // 운동/식단 게시글 수정 API
   const EditPostData = () => {
-    axios
+    api
       .put(
         EditPostUrl,
         {
@@ -55,7 +57,7 @@ function PostContent({ data, type, isEdit, setIsEdit }) {
 
   // 크루잉 게시글 수정 API
   const EditCrewingData = () => {
-    axios
+    api
       .put(
         EditCrewingUrl,
         {

--- a/client/src/Components/PostDetailPageBox.jsx
+++ b/client/src/Components/PostDetailPageBox.jsx
@@ -7,9 +7,10 @@ import { useDispatch, useSelector } from 'react-redux';
 import axios from 'axios';
 import postDataSlice from '../redux/reducers/postDataSlice';
 import useNotFoundPage from '../utils/hooks/useNotFoundPage';
+import { useApi } from '../utils/hooks/useApi';
 
 function PostDetailPageBox({ postId, type }) {
-  console.log('리렌더링 확인');
+  const api = useApi();
   const [isLoading, setIsLoading] = useState(true);
   const [isEdit, setIsEdit] = useState(false);
   const { notFound, NotFoundPage, handleNotFoundErrors } = useNotFoundPage();
@@ -30,11 +31,11 @@ function PostDetailPageBox({ postId, type }) {
     url = `${import.meta.env.VITE_API_URL}/posts/${postId}`;
   }
 
-  const accessToken = sessionStorage.getItem('authToken');
+  const accessToken = localStorage.getItem('authToken');
   const dispatch = useDispatch();
 
   const update = () => {
-    axios
+    api
       .get(url, {
         headers: {
           Authorization: accessToken,

--- a/client/src/Components/PostEditDelete.jsx
+++ b/client/src/Components/PostEditDelete.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { AuthorityBtn } from './PostEditDelete.style';
 import axios from 'axios';
+import { useApi } from '../utils/hooks/useApi';
 
 function PostEditDelete({ data, type, setIsEdit }) {
-  const loginId = sessionStorage.getItem('memberId') + '';
+  const api = useApi();
+  const loginId = localStorage.getItem('memberId') + '';
   const memberId = data.memberId + '';
-  const accessToken = sessionStorage.getItem('authToken');
+  const accessToken = localStorage.getItem('authToken');
   const deletePostUrl = `${import.meta.env.VITE_API_URL}/posts/${data.postId}`;
   const deleteCrewingUrl = `${import.meta.env.VITE_API_URL}/crewings/${
     data.crewingId
@@ -13,7 +15,7 @@ function PostEditDelete({ data, type, setIsEdit }) {
 
   // 운동/식단 게시글 삭제 API
   const DeletePostData = () => {
-    axios
+    api
       .delete(deletePostUrl, {
         headers: {
           Authorization: accessToken,
@@ -30,7 +32,7 @@ function PostEditDelete({ data, type, setIsEdit }) {
 
   // 크루잉 게시글 삭제 API
   const DeleteCrewingData = () => {
-    axios
+    api
       .delete(deleteCrewingUrl, {
         headers: {
           Authorization: accessToken,

--- a/client/src/Components/ProfileModal.jsx
+++ b/client/src/Components/ProfileModal.jsx
@@ -17,8 +17,10 @@ import axios from 'axios';
 import useImageCropAndUpload from '../utils/hooks/useImageCropAndUpload.js';
 import ImageCropper from './ImageCropper.jsx';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { useApi } from '../utils/hooks/useApi';
 
 function ProfileModal({ isModalOpen, handleModalToggle, memberId }) {
+  const api = useApi();
   const [showCropper, setShowCropper] = useState(false);
   const inputFileRef = useRef();
   const {
@@ -41,8 +43,8 @@ function ProfileModal({ isModalOpen, handleModalToggle, memberId }) {
   };
 
   const handleChangeButtonClick = () => {
-    const authToken = sessionStorage.getItem('authToken');
-    axios
+    const authToken = localStorage.getItem('authToken');
+    api
       .put(
         `${import.meta.env.VITE_API_URL}/members/${memberId}`,
         { imageUrl: uploadedImageUrl },

--- a/client/src/Components/UsernameModal.jsx
+++ b/client/src/Components/UsernameModal.jsx
@@ -14,8 +14,10 @@ import { faXmark } from '@fortawesome/free-solid-svg-icons';
 import axios from 'axios';
 import { checkNicknameDuplicate } from '../utils/signUpService';
 import { useState, useEffect } from 'react';
+import { useApi } from '../utils/hooks/useApi';
 
 function UsernameModal({ isModalOpen, handleModalToggle, memberId }) {
+  const api = useApi();
   const [newUsername, setNewUsername] = useState('');
   const [isValid, setIsValid] = useState(false);
   const [hasAttemptedInput, setHasAttemptedInput] = useState(false);
@@ -46,9 +48,12 @@ function UsernameModal({ isModalOpen, handleModalToggle, memberId }) {
   };
 
   const handleChangeButtonClick = () => {
-    const authToken = sessionStorage.getItem('authToken');
+    const authToken = localStorage.getItem('authToken');
+    const refreshToken = localStorage.getItem('refreshToken');
+    console.log('authToken : ' + authToken);
+    console.log('refreshToken : ' + refreshToken);
 
-    axios
+    api
       .put(
         `${import.meta.env.VITE_API_URL}/members/${memberId}`,
         { userName: newUsername },
@@ -65,7 +70,7 @@ function UsernameModal({ isModalOpen, handleModalToggle, memberId }) {
       .catch((error) => {
         console.log(error);
         alert('오류가 발생했습니다. 다시 시도해주세요.');
-        window.location.reload();
+        // window.location.reload();
       });
   };
 

--- a/client/src/Pages/MyPage.jsx
+++ b/client/src/Pages/MyPage.jsx
@@ -29,7 +29,7 @@ import usePortalModal from '../utils/hooks/usePortalModal';
 import { SettingsMain, SettingsMainContainer } from './Settings.style';
 
 function MyPage() {
-  const memberId = sessionStorage.getItem('memberId');
+  const memberId = localStorage.getItem('memberId');
   const [user, setUser] = useState({
     imageUrl: '/images/defaultprofile.png',
     username: 'Username',

--- a/client/src/Pages/Settings.jsx
+++ b/client/src/Pages/Settings.jsx
@@ -23,7 +23,7 @@ import PasswordModal from '../Components/PasswordModal';
 import ProfileModal from '../Components/ProfileModal';
 
 function Settings() {
-  const memberId = sessionStorage.getItem('memberId');
+  const memberId = localStorage.getItem('memberId');
   const [user, setUser] = useState({
     imageUrl: '/images/defaultprofile.png',
     username: 'default',

--- a/client/src/Pages/UserProfile.jsx
+++ b/client/src/Pages/UserProfile.jsx
@@ -30,7 +30,7 @@ import usePortalModal from '../utils/hooks/usePortalModal';
 
 function UserProfile() {
   const navigate = useNavigate();
-  const loggedInUserId = sessionStorage.getItem('memberId');
+  const loggedInUserId = localStorage.getItem('memberId');
   const { memberId: profileMemberId } = useParams();
   const [user, setUser] = useState({
     imageUrl: '/images/defaultprofile.png',

--- a/client/src/utils/PrivateRoute.jsx
+++ b/client/src/utils/PrivateRoute.jsx
@@ -1,9 +1,40 @@
+import { useState, useEffect } from 'react';
 import { useLocation, Navigate } from 'react-router-dom';
 import AuthRedirect from '../Components/AuthRedirect';
+import { useApi } from './hooks/useApi';
+import spinner from '../assets/loading-spinner.gif';
 
 function PrivateRoute({ children, path }) {
+  const api = useApi();
   const location = useLocation();
-  const isLoggedIn = Boolean(sessionStorage.getItem('authToken'));
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [isAuthenticating, setIsAuthenticating] = useState(true);
+  const authToken = localStorage.getItem('authToken');
+
+  useEffect(() => {
+    if (authToken) {
+      api
+        .post('/authentication', {}, { headers: { Authorization: authToken } })
+        .then((response) => {
+          if (response.status === 200) {
+            setIsLoggedIn(true);
+          }
+          setIsAuthenticating(false);
+        })
+        .catch((error) => {
+          console.error(error);
+          setIsLoggedIn(false);
+          setIsAuthenticating(false);
+        });
+    } else {
+      setIsAuthenticating(false);
+    }
+  }, [authToken, api]);
+
+  if (isAuthenticating) {
+    // Authentication is in progress. You can return a loading spinner or a similar placeholder here.
+    return <img style={{ width: '150px' }} src={spinner} alt="loading..." />;
+  }
 
   if (!isLoggedIn) {
     if (path !== '/') {

--- a/client/src/utils/ProfileLink.jsx
+++ b/client/src/utils/ProfileLink.jsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom';
 
 function ProfileLink({ profileUserId, element }) {
-  const loggedInUserId = Number(sessionStorage.getItem('memberId'));
+  const loggedInUserId = Number(localStorage.getItem('memberId'));
 
   const path =
     loggedInUserId === profileUserId ? '/mypage' : `/profile/${profileUserId}`;

--- a/client/src/utils/PublicRoute.jsx
+++ b/client/src/utils/PublicRoute.jsx
@@ -1,7 +1,7 @@
 import { Navigate } from 'react-router-dom';
 
 function PublicRoute({ children }) {
-  const isLoggedIn = Boolean(sessionStorage.getItem('authToken'));
+  const isLoggedIn = Boolean(localStorage.getItem('authToken'));
   if (isLoggedIn) {
     return <Navigate to="/" />;
   }

--- a/client/src/utils/hooks/useInfiniteScroll.js
+++ b/client/src/utils/hooks/useInfiniteScroll.js
@@ -1,6 +1,7 @@
 import { useInView } from 'react-intersection-observer';
 import axios from 'axios';
 import { useState } from 'react';
+import { useApi } from './useApi';
 
 const useInfiniteScroll = ({
   url,
@@ -10,7 +11,8 @@ const useInfiniteScroll = ({
   page,
   memberId,
 }) => {
-  const accessToken = sessionStorage.getItem('authToken');
+  const api = useApi();
+  const accessToken = localStorage.getItem('authToken');
   const [ref, inView] = useInView();
   const [loading, setLoading] = useState(false);
   const [lastPostId, setLastPostId] = useState(null);
@@ -21,7 +23,7 @@ const useInfiniteScroll = ({
     setLoading(true);
 
     if (page < 1) {
-      axios
+      api
         .get(
           url,
           { params: { category: category } },
@@ -43,7 +45,7 @@ const useInfiniteScroll = ({
           throw error;
         });
     } else if (page >= 1) {
-      axios
+      api
         .get(
           url,
           { params: { category: category, lastPostId: lastPostId } },
@@ -76,7 +78,7 @@ const useInfiniteScroll = ({
     setLoading(true);
 
     if (page < 1) {
-      axios
+      api
         .get(
           url,
           { params: { memberId: memberId } },
@@ -98,7 +100,7 @@ const useInfiniteScroll = ({
           throw error;
         });
     } else if (page >= 1) {
-      axios
+      api
         .get(
           url,
           { params: { memberId: memberId, lastPostId: lastPostId } },

--- a/client/src/utils/hooks/useLogout.js
+++ b/client/src/utils/hooks/useLogout.js
@@ -5,7 +5,7 @@ const useLogout = () => {
   const navigate = useNavigate();
 
   return () => {
-    const authToken = sessionStorage.getItem('authToken');
+    const authToken = localStorage.getItem('authToken');
 
     axios
       .post(
@@ -23,13 +23,13 @@ const useLogout = () => {
         }
 
         alert('성공적으로 로그아웃되었습니다');
-        sessionStorage.clear();
+        localStorage.clear();
         navigate('/login');
       })
       .catch((error) => {
         console.error(error);
         alert('오류가 발생했습니다. 다시 시도해주세요.');
-        sessionStorage.clear();
+        localStorage.clear();
         navigate('/login');
       });
   };

--- a/client/src/utils/hooks/usePortalModal.js
+++ b/client/src/utils/hooks/usePortalModal.js
@@ -5,7 +5,6 @@ function usePortalModal() {
   const [modalPosition, setModalPosition] = useState({ x: 0, y: 0 });
 
   const openModal = (event) => {
-    console.log('Open modal is called');
     const rect = event.target.getBoundingClientRect();
     setModalPosition({ x: rect.left, y: rect.bottom });
     setShowModal(true);

--- a/client/src/utils/hooks/useUpdatePost.js
+++ b/client/src/utils/hooks/useUpdatePost.js
@@ -2,11 +2,13 @@ import { useState } from 'react';
 import axios from 'axios';
 import { useDispatch } from 'react-redux';
 import postDataSlice from '../../redux/reducers/postDataSlice';
+import { useApi } from './useApi';
 
 // 특정 게시글의 postId를 인자로 전달받아,
 // postId에 해당되는 게시글의 데이터받아 전역상태로 저장하는 함수입니다.
 
 function useUpdatePost(postId, type, setIsLodig) {
+  const api = useApi();
   const [resCode, setResCode] = useState(0);
   let url = '';
 
@@ -16,12 +18,12 @@ function useUpdatePost(postId, type, setIsLodig) {
     url = `${import.meta.env.VITE_API_URL}/posts/${postId}`;
   }
 
-  const accessToken = sessionStorage.getItem('authToken');
+  const accessToken = localStorage.getItem('authToken');
   const dispatch = useDispatch();
   let resonseCode = 200;
 
   const update = () => {
-    axios
+    api
       .get(url, {
         headers: {
           Authorization: accessToken,


### PR DESCRIPTION
- [ ] 토큰을 첨부하여 보내는 api 요청에 한해, 401 응답 발생 시 리프레시 토큰 사용하여 토큰 재발급 후 기존 요청 재전송 로직 구현 및 적용
- [ ] PrivateRoute에서 auth토큰 유효성 검증 기능 추가
- [ ] 로그인 시 로그인 정보 저장 방식 sessionStorage => localStorage로 변경