### PR TITLE
feat: 프로필 페이지 크루잉 서브탭 구현

### DIFF
--- a/client/src/Components/CrewingEmptyListIndicator.jsx
+++ b/client/src/Components/CrewingEmptyListIndicator.jsx
@@ -1,0 +1,45 @@
+import { styled } from 'styled-components';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faFaceMeh } from '@fortawesome/free-regular-svg-icons';
+
+const Indicator = styled.section`
+  display: flex;
+  width: 100%;
+  height: 150px;
+  color: #c5c5c5;
+  margin: 10px 0;
+  align-items: center;
+`;
+
+const EmojiContainer = styled(FontAwesomeIcon)`
+  width: 80px;
+  height: 80px;
+`;
+
+const MessageContainer = styled.section`
+  display: flex;
+  flex-direction: column;
+  width: 300px;
+  margin-left: 20px;
+`;
+
+const MessageHeading = styled.section`
+  font-size: 25px;
+  margin-bottom: 5px;
+`;
+
+const MessageDetail = styled.section`
+  font-size: 16px;
+`;
+
+export default function CrewingEmptyListIndicator() {
+  return (
+    <Indicator>
+      <EmojiContainer icon={faFaceMeh} />
+      <MessageContainer>
+        <MessageHeading>아무것도 없네요...</MessageHeading>
+        <MessageDetail>아직 작성된 게시글이 없는 것 같아요.</MessageDetail>
+      </MessageContainer>
+    </Indicator>
+  );
+}

--- a/client/src/Components/CrewingTabContent.jsx
+++ b/client/src/Components/CrewingTabContent.jsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react';
-import Carditem from '../Components/Carditem';
-import { CardList } from '../Components/ShareBoard.style';
+import CrewingCardItem from '../Components/CrewingCardItem';
+import { CardList } from '../Components/CrewingBoard.style';
 import useInfiniteScroll from '../utils/hooks/useInfiniteScroll.js';
 import Loding from '../Components/Loding';
-import PostEmptyListIndicator from '../Components/PostEmptyListIndicator';
+import CrewingEmptyListIndicator from './CrewingEmptyListIndicator';
 
-function DietSubBoard({ memberId }) {
+function CrewingTabContent({ memberId, category }) {
   // get 요청 url
   const url = `${import.meta.env.VITE_API_URL}/members/getMyPosts/${memberId}`;
 
@@ -14,15 +14,21 @@ function DietSubBoard({ memberId }) {
   const [page, setPage] = useState(0); // page 상태에 따라 api 요청에 lastPostId params를 추가 (page가 1일 경우 lastPostId 쿼리 없이 데이터 요청, 1일 아닐 경우 lastPostId 쿼리를 추가하여 데이터 요청)
   const [ref, inView, getData, isLoadEnd] = useInfiniteScroll({
     url,
-    category: 'diet',
+    category,
     data,
     setData,
     page,
   });
 
+  // 카테고리가 바뀔 때마다 데이터를 재요청
   useEffect(() => {
-    if (inView) {
-      getData();
+    setData([]); // 데이터 초기화
+    setPage(0); // 페이지 초기화
+    getData(); // 데이터 재요청
+  }, [category]);
+
+  useEffect(() => {
+    if (inView && !isLoadEnd) {
       setPage(page + 1);
     }
   }, [inView]);
@@ -30,11 +36,11 @@ function DietSubBoard({ memberId }) {
   return (
     <>
       {data.length === 0 ? (
-        <PostEmptyListIndicator />
+        <CrewingEmptyListIndicator />
       ) : (
         <CardList>
           {data.map((item) => (
-            <Carditem item={item} key={item.postId} />
+            <CrewingCardItem item={item} key={item.postId} />
           ))}
         </CardList>
       )}
@@ -47,4 +53,4 @@ function DietSubBoard({ memberId }) {
   );
 }
 
-export default DietSubBoard;
+export default CrewingTabContent;

--- a/client/src/Components/PostDetailModal.jsx
+++ b/client/src/Components/PostDetailModal.jsx
@@ -30,7 +30,7 @@ function PostDetailModal({ postId, type, setIsModal }) {
         )}
       </div>
       {/* 함수형 컴포넌트에서는 useRef를 사용할 수 없기때문에 useRef를 사용하기 위해 생성한 div 태그 */}
-      <CloseBtn icon={closeIcon} onClick={closeModal} />
+      <CloseBtn icon={closeIcon} />
     </Modal>
   );
 }

--- a/client/src/Components/PostEmptyListIndicator.jsx
+++ b/client/src/Components/PostEmptyListIndicator.jsx
@@ -1,0 +1,38 @@
+import { faFaceMeh } from '@fortawesome/free-regular-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { styled } from 'styled-components';
+
+const Indicator = styled.section`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  color: #c5c5c5;
+  margin-top: 50px;
+`;
+
+const EmojiContainer = styled(FontAwesomeIcon)`
+  width: 80px;
+  height: 80px;
+  margin-bottom: 20px;
+`;
+
+const MessageHeading = styled.section`
+  font-size: 30px;
+  margin-bottom: 5px;
+`;
+
+const MessageDetail = styled.section`
+  font-size: 16px;
+`;
+
+export default function PostEmptyListIndicator() {
+  return (
+    <Indicator>
+      <EmojiContainer icon={faFaceMeh} />
+      <MessageHeading>아무것도 없네요...</MessageHeading>
+      <MessageDetail>아직 작성된 게시글이 없는 것 같아요.</MessageDetail>
+    </Indicator>
+  );
+}

--- a/client/src/Pages/CrewingSubBoard.jsx
+++ b/client/src/Pages/CrewingSubBoard.jsx
@@ -1,41 +1,31 @@
-import { useEffect, useState } from 'react';
-import CrewingCardItem from '../Components/CrewingCardItem';
-import { CardList } from '../Components/ShareBoard.style';
-import useInfiniteScroll from '../utils/hooks/useInfiniteScroll.js';
-import Loding from '../Components/Loding';
+import { useState } from 'react';
+import CrewingTabContent from '../Components/CrewingTabContent';
+import { TabList, Tab } from './CrewingSubBoard.style';
 
 function CrewingSubBoard({ memberId }) {
-  // get 요청 url
-  const url = `${import.meta.env.VITE_API_URL}/members/getMyPosts/${memberId}`;
+  // 탭 상태 (기본값 'crewing')
+  const [tab, setTab] = useState('crewing');
 
-  // 무한스크롤 API
-  const [data, setData] = useState([]); // getData 함수를 통해 받아온 데이터의 상태 (Carditem에 전달 될 데이터)
-  const [page, setPage] = useState(0); // page 상태에 따라 api 요청에 lastPostId params를 추가 (page가 1일 경우 lastPostId 쿼리 없이 데이터 요청, 1일 아닐 경우 lastPostId 쿼리를 추가하여 데이터 요청)
-  const [ref, inView, getData, isLoadEnd] = useInfiniteScroll({
-    url,
-    category: 'crewing',
-    data,
-    setData,
-    page,
-  });
-
-  useEffect(() => {
-    if (inView) {
-      getData();
-      setPage(page + 1);
-    }
-  }, [inView]);
+  // 탭 변경 함수
+  const changeTab = (newTab) => {
+    setTab(newTab);
+    window.scrollTo(0, 0); // 스크롤 위치 초기화
+  };
 
   return (
     <>
-      <CardList>
-        {data &&
-          data.map((item) => <CrewingCardItem item={item} key={item.postId} />)}
-      </CardList>
-      {isLoadEnd ? undefined : (
-        <div ref={ref}>
-          <Loding />
-        </div>
+      <TabList>
+        <Tab onClick={() => changeTab('crewing')} isActive={tab === 'crewing'}>
+          내가 모집한 크루잉
+        </Tab>
+        <Tab onClick={() => changeTab('apply')} isActive={tab === 'apply'}>
+          내가 참여한 크루잉
+        </Tab>
+      </TabList>
+      {tab === 'crewing' ? (
+        <CrewingTabContent memberId={memberId} category={tab} />
+      ) : (
+        <CrewingTabContent memberId={memberId} category={tab} />
       )}
     </>
   );

--- a/client/src/Pages/CrewingSubBoard.style.js
+++ b/client/src/Pages/CrewingSubBoard.style.js
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+
+export const TabList = styled.section`
+  display: flex;
+  width: 100%;
+`;
+
+export const Tab = styled.section`
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 150px;
+  height: 50px;
+  color: ${({ isActive }) => (isActive ? 'black' : '#a8a8a8')};
+  font-weight: ${({ isActive }) => (isActive ? 'bold' : 'normal')};
+  border-bottom: ${({ isActive }) => (isActive ? '2px solid black' : 'none')};
+`;

--- a/client/src/Pages/ProfilePage.style.js
+++ b/client/src/Pages/ProfilePage.style.js
@@ -76,7 +76,7 @@ export const UserStatNumber = styled.section`
   width: 45px;
 `;
 
-export const LinksContainer = styled.section`
+export const TabContainer = styled.section`
   display: flex;
   width: 100%;
   justify-content: center;
@@ -84,7 +84,7 @@ export const LinksContainer = styled.section`
   margin: 30px 0;
 `;
 
-export const LinkItem = styled(NavLink)`
+export const TabItem = styled.section`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -93,10 +93,15 @@ export const LinkItem = styled(NavLink)`
   color: #a8a8a8;
   text-decoration: none;
   font-size: 20px;
-  &.active {
+  cursor: pointer;
+
+  ${(props) =>
+    props.isActive &&
+    `
     font-weight: bold;
     pointer-events: none;
     color: black;
     border-bottom: 2px solid black;
-  }
+    cursor: default;
+  `}
 `;

--- a/client/src/Pages/UserProfile.jsx
+++ b/client/src/Pages/UserProfile.jsx
@@ -2,8 +2,8 @@ import { useEffect, useState } from 'react';
 import { Routes, Route, useParams, useNavigate } from 'react-router-dom';
 import { Navigate } from 'react-router-dom';
 import {
-  LinksContainer,
-  LinkItem,
+  TabContainer,
+  TabItem,
   ProfilePictureContainer,
   UserInfoContainer,
   UserProfileContainer,
@@ -27,6 +27,7 @@ import useNotFoundPage from '../utils/hooks/useNotFoundPage';
 import PortalModal from '../utils/PortalModal';
 import FollowList from '../Components/FollowList';
 import usePortalModal from '../utils/hooks/usePortalModal';
+import CrewingTabContent from '../Components/CrewingTabContent';
 
 function UserProfile() {
   const navigate = useNavigate();
@@ -34,19 +35,28 @@ function UserProfile() {
   const { memberId: profileMemberId } = useParams();
   const [user, setUser] = useState({
     imageUrl: '/images/defaultprofile.png',
-    username: 'Username',
-    totalPostsCount: 10,
-  }); // Mockup data
+    username: '_',
+    totalPostsCount: 0,
+  });
   const [userFollowInfo, setUserFollowInfo] = useState({});
-  const [userFollowerList, setUserFollowerList] = useState(
-    new Array(5).fill({})
-  ); // Mockup data
-  const [userFollowingList, setUserFollowingList] = useState(
-    new Array(3).fill({})
-  ); // Mockup data
+  const [userFollowerList, setUserFollowerList] = useState([]);
+  const [userFollowingList, setUserFollowingList] = useState([]);
 
   const followerModal = usePortalModal();
   const followingModal = usePortalModal();
+
+  const [selectedTab, setSelectedTab] = useState('workout');
+  const selectTab = (tab) => {
+    setSelectedTab(tab);
+  };
+
+  const TabComponent = {
+    workout: WorkoutSubBoard,
+    diet: DietSubBoard,
+    crewing: (props) => <CrewingTabContent {...props} category="crewing" />,
+  };
+
+  const SelectedTabComponent = TabComponent[selectedTab];
 
   const { notFound, NotFoundPage, handleNotFoundErrors } = useNotFoundPage();
 
@@ -169,26 +179,27 @@ function UserProfile() {
               </UserStatsContainer>
             </UserInfoContainer>
           </UserProfileContainer>
-          <LinksContainer>
-            <LinkItem to="workout">운동</LinkItem>
-            <LinkItem to="diet">식단</LinkItem>
-            <LinkItem to="crewing">크루잉</LinkItem>
-          </LinksContainer>
-          <Routes>
-            <Route
-              path="workout"
-              element={<WorkoutSubBoard memberId={profileMemberId} />}
-            />
-            <Route
-              path="diet"
-              element={<DietSubBoard memberId={profileMemberId} />}
-            />
-            <Route
-              path="crewing"
-              element={<CrewingSubBoard memberId={profileMemberId} />}
-            />
-            <Route path="/" element={<Navigate to="workout" replace />} />
-          </Routes>
+          <TabContainer>
+            <TabItem
+              onClick={() => selectTab('workout')}
+              isActive={selectedTab === 'workout'}
+            >
+              운동
+            </TabItem>
+            <TabItem
+              onClick={() => selectTab('diet')}
+              isActive={selectedTab === 'diet'}
+            >
+              식단
+            </TabItem>
+            <TabItem
+              onClick={() => selectTab('crewing')}
+              isActive={selectedTab === 'crewing'}
+            >
+              크루잉
+            </TabItem>
+          </TabContainer>
+          <SelectedTabComponent memberId={profileMemberId} />
         </ProfilePageMain>
       </MainContainer>
     </>

--- a/client/src/Pages/WorkoutSubBoard.jsx
+++ b/client/src/Pages/WorkoutSubBoard.jsx
@@ -3,6 +3,7 @@ import Carditem from '../Components/Carditem';
 import { CardList } from '../Components/ShareBoard.style';
 import useInfiniteScroll from '../utils/hooks/useInfiniteScroll.js';
 import Loding from '../Components/Loding';
+import PostEmptyListIndicator from '../Components/PostEmptyListIndicator';
 
 function WorkoutSubBoard({ memberId }) {
   // get 요청 url
@@ -28,9 +29,15 @@ function WorkoutSubBoard({ memberId }) {
 
   return (
     <>
-      <CardList>
-        {data && data.map((item) => <Carditem item={item} key={item.postId} />)}
-      </CardList>
+      {data.length === 0 ? (
+        <PostEmptyListIndicator />
+      ) : (
+        <CardList>
+          {data.map((item) => (
+            <Carditem item={item} key={item.postId} />
+          ))}
+        </CardList>
+      )}
       {isLoadEnd ? undefined : (
         <div ref={ref}>
           <Loding />


### PR DESCRIPTION
- 프로필 페이지 탭을 루트/링크로 구현된 기존 방식에서 상태를 활용한 탭 방식으로 변경
- 크루잉 탭의 하위 탭을 CrewingTabContent로 분리
- 프로필 페이지에서 탭이 비어있을 경우 보여줄 PostEmptyListIndicator, CrewingEmptyListIndicator 구현 및 적용